### PR TITLE
fix ##51: Allow port to be set via process.env.PORT

### DIFF
--- a/server.js
+++ b/server.js
@@ -13,7 +13,6 @@ dotenv.config();
 
 const PORT = process.env.PORT || 3000;
 
-
 const app = express();
 app.use(express.static("public"));
 app.use(express.urlencoded({ extended: true }));

--- a/server.js
+++ b/server.js
@@ -11,6 +11,9 @@ import routes from "./src/routes/index.js";
 
 dotenv.config();
 
+const PORT = process.env.PORT || 3000;
+
+
 const app = express();
 app.use(express.static("public"));
 app.use(express.urlencoded({ extended: true }));
@@ -100,4 +103,4 @@ app.use("/m", cors(), routes.message);
 app.use("/", routes.core);
 app.use("/api/inbox", cors(), routes.inbox);
 
-app.listen(3000, () => console.log(`App listening on port 3000`));
+app.listen(PORT, () => console.log(`App listening on port ${ PORT }`));


### PR DESCRIPTION
This change allows the port to be set using the .env file, but defaults to 3000