### PR TITLE
fix #54: log to request_logs.txt only if LOGGING_ENABLED===true

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ To set your app up:
 * Click on the __Admin__ link in the footer, and enter the password (whatever you set ADMIN_KEY to in the .env).
 * You should be logged in, at which point you can configure various settings, import bookmarks, and use the "Add" links in the header and footer (as well as the bookmarklet, available in the Admin section) to save new bookmarks.
 
+## Developing Postmarks
+
+* To automatically log all requests to a text file, set add `LOGGING_ENABLED=true` to your .env file. This will cause all incoming requests to `request_log.txt` in your project folder.
+
 ## Acknowledgments
 
 * The "Postmarks" name is compliments of [Casey C](https://sowe.li) (no relation to Casey K), who brainstormed dozens of ideas for the name when Casey was first trying to rename the project. Thank you!

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ To set your app up:
 
 ## Developing Postmarks
 
-* To automatically log all requests to a text file, set add `LOGGING_ENABLED=true` to your .env file. This will cause all incoming requests to `request_log.txt` in your project folder.
+* To automatically log all requests to a text file, set add `LOGGING_ENABLED=true` to your .env file. This will cause all incoming requests to append to `request_log.txt` in your project folder.
 
 ## Acknowledgments
 

--- a/src/util.js
+++ b/src/util.js
@@ -113,10 +113,12 @@ export function simpleLogger(req, res, next) { //middleware function
 
   let log = `[${chalk.blue(formatted_date)}] ${method}:${url} ${status} ${chalk.red(durationInMilliseconds.toLocaleString() + "ms")}`;
   console.log(log);
-  fs.appendFile("request_logs.txt", log + "\n", err => {
-    if (err) {
-      console.log(err);
-    }
-  });
+  if (process.env.LOGGING_ENABLED === "true") {
+    fs.appendFile("request_logs.txt", log + "\n", err => {
+      if (err) {
+        console.log(err);
+      }
+    });
+  }
   next();
 };


### PR DESCRIPTION
@ckolderup how do you feel about this variable name?
if ok, should I put a note in the readme?

Another approach would be to use the `ENVIRONMENT===production` test, but that is currently tied to SSL behavior which you may not want to trigger