### PR TITLE
Adding support for inbound nodeinfo queries

### DIFF
--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@ import * as dotenv from "dotenv";
 import express from "express";
 import cors from "cors";
 import { create } from "express-handlebars";
+
 import { domain, account, simpleLogger, actorInfo } from "./src/util.js";
 import session, { isAuthenticated } from "./src/session-auth.js";
 import * as bookmarksDb from "./src/bookmarks-db.js";
@@ -30,6 +31,8 @@ app.set("bookmarksDb", bookmarksDb);
 app.set("apDb", apDb);
 app.set("account", account);
 app.set("domain", domain);
+
+app.disable("x-powered-by");
 
 //force HTTPS in production
 if (process.env.ENVIRONMENT === "production") {
@@ -101,5 +104,7 @@ app.use("/u", cors(), routes.user);
 app.use("/m", cors(), routes.message);
 app.use("/", routes.core);
 app.use("/api/inbox", cors(), routes.inbox);
+app.use("/.well-known/nodeinfo", routes.nodeinfo)
+app.use("/nodeinfo/2.0", routes.nodeinfo)
 
 app.listen(PORT, () => console.log(`App listening on port ${ PORT }`));

--- a/src/routes/activitypub/nodeinfo.js
+++ b/src/routes/activitypub/nodeinfo.js
@@ -1,0 +1,61 @@
+// implementation of http://nodeinfo.diaspora.software/protocol.html
+
+import express from "express";
+import {instanceType, instanceVersion} from "../../util.js";
+
+export const router = express.Router();
+
+router.get("/", async function (req, res) {
+  let domain = req.app.get("domain");
+
+  if (req.originalUrl == "/.well-known/nodeinfo") {
+    let thisNode = {
+      links: [
+        {
+          rel: "http://nodeinfo.diaspora.software/ns/schema/2.0",
+          href: `https://${domain}/nodeinfo/2.0`,
+        },
+      ],
+    };
+    res.json(thisNode);
+  }
+
+  if (req.originalUrl == "/nodeinfo/2.0") {
+
+    const bookmarksDb = req.app.get("bookmarksDb");
+    let bookmarkCount = await bookmarksDb.getBookmarkCount();
+
+    // TODO: activeMonth and activeHalfyear should be dynamic, currently static
+    let nodeInfo = {
+      version: 2.0,
+      software: {
+        name: instanceType,
+        version: instanceVersion,
+      },
+      protocols: [
+        "activitypub"
+      ],
+      services: {
+        outbound: ["atom1.0"],
+        inbound: []
+      },
+      usage: {
+        users: {
+          total: 1,
+          activeMonth: 1,
+          activeHalfyear: 1
+        },
+        localPosts: bookmarkCount,
+      },
+      openRegistrations: false,
+      metadata: {}
+    };
+
+    // spec requires setting this, majority of implementations
+    // appear to not bother with it?
+    res.type('application/json; profile="http://nodeinfo.diaspora.software/ns/schema/2.0#"')
+
+    res.json(nodeInfo);
+
+  }
+});

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -7,6 +7,7 @@ import { router as inbox } from './activitypub/inbox.js';
 import { router as message } from './activitypub/message.js';
 import { router as user } from './activitypub/user.js';
 import { router as webfinger } from './activitypub/webfinger.js';
+import { router as nodeinfo } from './activitypub/nodeinfo.js';
 
 export default {
   admin,
@@ -18,4 +19,5 @@ export default {
   message,
   user,
   webfinger,
+  nodeinfo,
 };

--- a/src/util.js
+++ b/src/util.js
@@ -24,6 +24,16 @@ export const actorInfo = actorFileData;
 export const account = actorInfo.username || 'bookmarks';
 export const domain = process.env.PROJECT_DOMAIN ? `${process.env.PROJECT_DOMAIN}.glitch.me` : 'localhost'; // edit this if you have a custom domain
 
+let instanceData = {};
+try {
+  const pkgFile = await readFile('package.json');
+  instanceData = JSON.parse(pkgFile);
+} catch (e) {
+  console.log("unable to read package info");
+}
+
+export const instanceType = instanceData.name || 'postmarks';
+export const instanceVersion = instanceData.version || 'undefined';
 
 export function timeSince(ms)  {
   var timestamp = new Date(ms);


### PR DESCRIPTION
Added a new route handler for queries to the server's `nodeinfo` routes, specifically the `.well-known/nodeinfo` and `nodeinfo/2.0` endpoints.

The actual capabilities reported by these endpoints may be improved in the future (for example, for now, the `usage` information related to user activity is largely static).

Closes #73 