### PR TITLE
Mastodon verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ To set your app up:
 * Click on the __Admin__ link in the footer, and enter the password (whatever you set ADMIN_KEY to in the .env).
 * You should be logged in, at which point you can configure various settings, import bookmarks, and use the "Add" links in the header and footer (as well as the bookmarklet, available in the Admin section) to save new bookmarks.
 
+## Mastodon Verification
+
+Setting `MASTODON_ACCOUNT` in the `.env` file will cause a link to be added to the Postmarks home page that can be used for verification with your Mastodon account. See the [Mastodon documentation](https://docs.joinmastodon.org/user/profile/#verification) for more details.
 ## Developing Postmarks
 
 * To automatically log all requests to a text file, set add `LOGGING_ENABLED=true` to your .env file. This will cause all incoming requests to append to `request_log.txt` in your project folder.

--- a/server.js
+++ b/server.js
@@ -84,6 +84,9 @@ const hbs = create({
       this._sections[name] = options.fn(this);
       return null;
     },
+    mastodonAccount() {
+      return process.env.MASTODON_ACCOUNT;
+    }
   },
   partialsDir: "./src/pages/partials",
   extname: ".hbs",

--- a/src/pages/layouts/main.hbs
+++ b/src/pages/layouts/main.hbs
@@ -4,6 +4,9 @@
     <meta charset="utf-8" />
     <link rel="icon" href="https://glitch.com/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    {{#if (mastodonAccount) }}
+    <link rel="me" href="{{ mastodonAccount }}" />
+    {{/if}}
     {{{feedLink}}}
 
     <title>{{title}} | {{siteName}}</title>


### PR DESCRIPTION
Provides a feature that allows `MASTODON_ACCOUNT` to be defined in the `.env` file. This will cause a link element to be added to the main layout HEAD element that will allow verification from the specified Mastodon account. Closes #75