### PR TITLE
routes/bookmark.js: quick fix for multi bookmark import.

### DIFF
--- a/src/routes/bookmark.js
+++ b/src/routes/bookmark.js
@@ -169,7 +169,7 @@ router.post("/multiadd", isAuthenticated, async (req, res) => {
 
     let meta = {};
     try {
-      meta = await ogScraper({ url });
+      meta = await ogScraper({ url: url.replace(/(\r\n|\n|\r)/gm,"") }); // remove line break from URL value
       if (meta?.result?.ogDescription !== undefined) {
         meta.result.ogDescription = `"${meta.result.ogDescription}"`;
       }


### PR DESCRIPTION
Simple fix (regex to clean newlines from URL values) to make the current bookmark import functionality work.
Could be improved by having more sophisticated validation for the URLs.

Hopefully a stopgap while a more complete import/export set of capabilities are considered.