### PR TITLE
Add HTTP signature to GET requests to support Mastodon's AUTHORIZED_FETCH setting.

### DIFF
--- a/src/activitypub.js
+++ b/src/activitypub.js
@@ -1,69 +1,59 @@
-import fetch from "node-fetch";
-import crypto from "crypto";
+import fetch from 'node-fetch';
+import crypto from 'crypto';
 
-import { signedFetch } from "./signature.js";
-import { actorInfo, actorMatchesUsername } from "./util.js";
+import { signedFetch } from './signature.js';
+import { actorInfo, actorMatchesUsername } from './util.js';
 
 function getGuidFromPermalink(urlString) {
   return urlString.match(/m\/([a-zA-Z0-9+\/]+)/)[1];
 }
 
-export async function signAndSend(
-  message,
-  name,
-  domain,
-  db,
-  targetDomain,
-  inbox
-) {
+export async function signAndSend(message, name, domain, db, targetDomain, inbox) {
   try {
     const response = await signedFetch(inbox, {
       body: JSON.stringify(message),
-      method: "POST",
+      method: 'POST',
     });
     const data = await response.text();
 
     console.log(`Sent message to an inbox at ${targetDomain}!`);
-    console.log("Response Status Code:", response.status);
-    console.log("Response body:", data);
+    console.log('Response Status Code:', response.status);
+    console.log('Response body:', data);
   } catch (error) {
-    console.log("Error:", error.message);
-    console.log("Stacktrace: ", error.stack);
+    console.log('Error:', error.message);
+    console.log('Stacktrace: ', error.stack);
   }
 }
 
 export function createNoteObject(bookmark, account, domain) {
-  const guidNote = crypto.randomBytes(16).toString("hex");
+  const guidNote = crypto.randomBytes(16).toString('hex');
   const d = new Date();
 
   const linkedTags = bookmark.tags
-    ?.split(" ")
+    ?.split(' ')
     .map((tag) => {
       const tagName = tag.slice(1);
       return `<a href=\"https://${domain}/tagged/${tagName}\" class=\"mention hashtag\" rel=\"tag\">${tag}</a>`;
     })
-    .join(" ");
+    .join(' ');
 
   const noteMessage = {
-    "@context": "https://www.w3.org/ns/activitystreams",
+    '@context': 'https://www.w3.org/ns/activitystreams',
     id: `https://${domain}/m/${guidNote}`,
-    type: "Note",
+    type: 'Note',
     published: d.toISOString(),
     attributedTo: `https://${domain}/u/${account}`,
     content: `
       <strong><a href="${bookmark.url}">${bookmark.title}</a></strong><br/>
-      ${bookmark.description?.replace("\n", "<br/>") || ""}`,
-    to: [
-      `https://${domain}/u/${account}/followers/`,
-      "https://www.w3.org/ns/activitystreams#Public",
-    ],
+      ${bookmark.description?.replace('\n', '<br/>') || ''}`,
+    to: [`https://${domain}/u/${account}/followers/`, 'https://www.w3.org/ns/activitystreams#Public'],
     tag: [],
   };
 
-  bookmark.tags?.split(" ").forEach((tag) => {
+  bookmark.tags?.split(' ').forEach((tag) => {
     const tagName = tag.slice(1);
     noteMessage.tag.push({
-      type: "Hashtag",
+      type: 'Hashtag',
       href: `https://${domain}/tagged/${tagName}`,
       name: tag,
     });
@@ -86,12 +76,9 @@ async function createUpdateMessage(bookmark, account, domain, db) {
   }
 
   const updateMessage = {
-    "@context": [
-      "https://www.w3.org/ns/activitystreams",
-      "https://w3id.org/security/v1",
-    ],
+    '@context': ['https://www.w3.org/ns/activitystreams', 'https://w3id.org/security/v1'],
     summary: `${account} updated the bookmark`,
-    type: "Create", // this should be 'Update' but Mastodon does weird things with Updates
+    type: 'Create', // this should be 'Update' but Mastodon does weird things with Updates
     actor: `https://${domain}/u/${account}`,
     object: note,
   };
@@ -100,28 +87,18 @@ async function createUpdateMessage(bookmark, account, domain, db) {
 }
 
 function createMessage(noteObject, bookmarkId, account, domain, db) {
-  const guidCreate = crypto.randomBytes(16).toString("hex");
+  const guidCreate = crypto.randomBytes(16).toString('hex');
 
   const createMessage = {
-    "@context": [
-      "https://www.w3.org/ns/activitystreams",
-      "https://w3id.org/security/v1",
-    ],
+    '@context': ['https://www.w3.org/ns/activitystreams', 'https://w3id.org/security/v1'],
     id: `https://${domain}/m/${guidCreate}`,
-    type: "Create",
+    type: 'Create',
     actor: `https://${domain}/u/${account}`,
-    to: [
-      `https://${domain}/u/${account}/followers/`,
-      "https://www.w3.org/ns/activitystreams#Public",
-    ],
+    to: [`https://${domain}/u/${account}/followers/`, 'https://www.w3.org/ns/activitystreams#Public'],
     object: noteObject,
   };
 
-  db.insertMessage(
-    getGuidFromPermalink(noteObject.id),
-    bookmarkId,
-    JSON.stringify(noteObject)
-  );
+  db.insertMessage(getGuidFromPermalink(noteObject.id), bookmarkId, JSON.stringify(noteObject));
 
   return createMessage;
 }
@@ -131,19 +108,13 @@ async function createDeleteMessage(bookmark, account, domain, db) {
   await db.deleteMessage(guid);
 
   const deleteMessage = {
-    "@context": [
-      "https://www.w3.org/ns/activitystreams",
-      "https://w3id.org/security/v1",
-    ],
+    '@context': ['https://www.w3.org/ns/activitystreams', 'https://w3id.org/security/v1'],
     id: `https://${domain}/m/${guid}`,
-    type: "Delete",
+    type: 'Delete',
     actor: `https://${domain}/u/${account}`,
-    to: [
-      `https://${domain}/u/${account}/followers/`,
-      "https://www.w3.org/ns/activitystreams#Public",
-    ],
+    to: [`https://${domain}/u/${account}/followers/`, 'https://www.w3.org/ns/activitystreams#Public'],
     object: {
-      type: "Tombstone",
+      type: 'Tombstone',
       id: `https://${domain}/m/${guid}`,
     },
   };
@@ -152,11 +123,11 @@ async function createDeleteMessage(bookmark, account, domain, db) {
 }
 
 export async function createFollowMessage(account, domain, target, db) {
-  const guid = crypto.randomBytes(16).toString("hex");
+  const guid = crypto.randomBytes(16).toString('hex');
   const followMessage = {
-    "@context": "https://www.w3.org/ns/activitystreams",
+    '@context': 'https://www.w3.org/ns/activitystreams',
     id: guid,
-    type: "Follow",
+    type: 'Follow',
     actor: `https://${domain}/u/${account}`,
     object: target,
   };
@@ -167,30 +138,28 @@ export async function createFollowMessage(account, domain, target, db) {
 }
 
 export async function createUnfollowMessage(account, domain, target, db) {
-  const undoGuid = crypto.randomBytes(16).toString("hex");
+  const undoGuid = crypto.randomBytes(16).toString('hex');
 
   const messageRows = await db.findMessage(target);
 
-  console.log("result", messageRows);
+  console.log('result', messageRows);
 
   const followMessages = messageRows?.filter((row) => {
-    const message = JSON.parse(row.message || "{}");
-    return message.type === "Follow" && message.object === target;
+    const message = JSON.parse(row.message || '{}');
+    return message.type === 'Follow' && message.object === target;
   });
 
   if (followMessages?.length > 0) {
     const undoMessage = {
-      "@context": "https://www.w3.org/ns/activitystreams",
-      type: "Undo",
+      '@context': 'https://www.w3.org/ns/activitystreams',
+      type: 'Undo',
       id: undoGuid,
       actor: `${domain}/u/${account}`,
       object: followMessages.slice(-1).message,
     };
     return undoMessage;
   } else {
-    console.log(
-      "tried to find a Follow record in order to unfollow, but failed"
-    );
+    console.log('tried to find a Follow record in order to unfollow, but failed');
     return null;
   }
 }
@@ -202,22 +171,18 @@ export async function getInboxFromActorProfile(profileUrl) {
   if (data?.inbox) {
     return data.inbox;
   } else {
-    throw new Error(
-      `Couldn't find inbox at supplied profile url ${profileUrl}`
-    );
+    throw new Error(`Couldn't find inbox at supplied profile url ${profileUrl}`);
   }
 }
 
 // actorUsername format is @username@domain
 export async function lookupActorInfo(actorUsername) {
-  const parsedDomain = actorUsername.split("@").slice(-1);
-  const parsedUsername = actorUsername.split("@").slice(-2, -1);
+  const parsedDomain = actorUsername.split('@').slice(-1);
+  const parsedUsername = actorUsername.split('@').slice(-2, -1);
   try {
-    const response = await fetch(
-      `https://${parsedDomain}/.well-known/webfinger/?resource=acct:${parsedUsername}@${parsedDomain}`
-    );
+    const response = await fetch(`https://${parsedDomain}/.well-known/webfinger/?resource=acct:${parsedUsername}@${parsedDomain}`);
     const data = await response.json();
-    const selfLink = data.links.find((o) => o.rel === "self");
+    const selfLink = data.links.find((o) => o.rel === 'self');
     if (!selfLink || !selfLink.href) {
       throw new Error();
     }
@@ -244,8 +209,8 @@ export async function broadcastMessage(bookmark, action, db, account, domain) {
     const globalPermissions = await db.getGlobalPermissions();
     const blocklist =
       bookmarkPermissions?.blocked
-        ?.split("\n")
-        ?.concat(globalPermissions?.blocked?.split("\n"))
+        ?.split('\n')
+        ?.concat(globalPermissions?.blocked?.split('\n'))
         .filter((x) => !x?.match(/^@([^@]+)@(.+)$/)) || [];
 
     //now let's try to remove the blocked users
@@ -260,26 +225,24 @@ export async function broadcastMessage(bookmark, action, db, account, domain) {
     const noteObject = createNoteObject(await bookmark, account, domain);
     let message;
     switch (action) {
-      case "create":
+      case 'create':
         message = createMessage(noteObject, bookmark.id, account, domain, db);
         break;
-      case "update":
+      case 'update':
         message = await createUpdateMessage(bookmark, account, domain, db);
         break;
-      case "delete":
+      case 'delete':
         message = await createDeleteMessage(bookmark, account, domain, db);
         break;
       default:
-        console.log("unsupported action!");
+        console.log('unsupported action!');
         return;
     }
 
-    console.log(
-      `sending this message to all followers: ${JSON.stringify(message)}`
-    );
+    console.log(`sending this message to all followers: ${JSON.stringify(message)}`);
 
     for (let follower of followers) {
-      let inbox = follower + "/inbox";
+      let inbox = follower + '/inbox';
       let myURL = new URL(follower);
       let targetDomain = myURL.host;
       signAndSend(message, account, domain, db, targetDomain, inbox);

--- a/src/activitypub.js
+++ b/src/activitypub.js
@@ -1,7 +1,7 @@
 import fetch from 'node-fetch';
 import crypto from 'crypto';
 
-import { signedFetch } from './signature.js';
+import { signedGetJSON, signedPostJSON } from './signature.js';
 import { actorInfo, actorMatchesUsername } from './util.js';
 
 function getGuidFromPermalink(urlString) {
@@ -10,9 +10,8 @@ function getGuidFromPermalink(urlString) {
 
 export async function signAndSend(message, name, domain, db, targetDomain, inbox) {
   try {
-    const response = await signedFetch(inbox, {
+    const response = await signedPostJSON(inbox, {
       body: JSON.stringify(message),
-      method: 'POST',
     });
     const data = await response.text();
 
@@ -165,7 +164,7 @@ export async function createUnfollowMessage(account, domain, target, db) {
 }
 
 export async function getInboxFromActorProfile(profileUrl) {
-  const response = await signedFetch(`${profileUrl}.json`);
+  const response = await signedGetJSON(`${profileUrl}.json`);
   const data = await response.json();
 
   if (data?.inbox) {

--- a/src/routes/activitypub/inbox.js
+++ b/src/routes/activitypub/inbox.js
@@ -1,27 +1,20 @@
-import express from "express";
-import crypto from "crypto";
-import * as linkify from "linkifyjs";
+import express from 'express';
+import crypto from 'crypto';
+import * as linkify from 'linkifyjs';
 
-import { actorMatchesUsername, parseJSON } from "../../util.js";
-import { signAndSend, getInboxFromActorProfile } from "../../activitypub.js";
-import { signedFetch } from "../../signature.js";
+import { actorMatchesUsername, parseJSON } from '../../util.js';
+import { signAndSend, getInboxFromActorProfile } from '../../activitypub.js';
+import { signedFetch } from '../../signature.js';
 
 export const router = express.Router();
 
-async function sendAcceptMessage(
-  thebody,
-  name,
-  domain,
-  req,
-  res,
-  targetDomain
-) {
-  const db = req.app.get("apDb");
-  const guid = crypto.randomBytes(16).toString("hex");
+async function sendAcceptMessage(thebody, name, domain, req, res, targetDomain) {
+  const db = req.app.get('apDb');
+  const guid = crypto.randomBytes(16).toString('hex');
   let message = {
-    "@context": "https://www.w3.org/ns/activitystreams",
+    '@context': 'https://www.w3.org/ns/activitystreams',
     id: `https://${domain}/u/${name}/accept/${guid}`,
-    type: "Accept",
+    type: 'Accept',
     actor: `https://${domain}/u/${name}`,
     object: thebody,
   };
@@ -32,18 +25,18 @@ async function sendAcceptMessage(
 }
 
 async function handleFollowRequest(req, res) {
-  const domain = req.app.get("domain");
-  const apDb = req.app.get("apDb");
+  const domain = req.app.get('domain');
+  const apDb = req.app.get('apDb');
 
   const myURL = new URL(req.body.actor);
   const targetDomain = myURL.hostname;
-  const name = req.body.object.replace(`https://${domain}/u/`, "");
+  const name = req.body.object.replace(`https://${domain}/u/`, '');
 
   await sendAcceptMessage(req.body, name, domain, req, res, targetDomain);
   // Add the user to the DB of accounts that follow the account
 
   // get the followers JSON for the user
-  const oldFollowersText = (await apDb.getFollowers()) || "[]";
+  const oldFollowersText = (await apDb.getFollowers()) || '[]';
 
   // update followers
   let followers = parseJSON(oldFollowersText);
@@ -59,26 +52,26 @@ async function handleFollowRequest(req, res) {
     // update into DB
     const newFollowers = await apDb.setFollowers(newFollowersText);
 
-    console.log("updated followers!");
+    console.log('updated followers!');
   } catch (e) {
-    console.log("error storing followers after follow", e);
+    console.log('error storing followers after follow', e);
   }
 
   return res.status(200);
 }
 
 async function handleUnfollow(req, res) {
-  const domain = req.app.get("domain");
-  const apDb = req.app.get("apDb");
+  const domain = req.app.get('domain');
+  const apDb = req.app.get('apDb');
 
   const myURL = new URL(req.body.actor);
   const targetDomain = myURL.hostname;
-  const name = req.body.object.replace(`https://${domain}/u/`, "");
+  const name = req.body.object.replace(`https://${domain}/u/`, '');
 
   await sendAcceptMessage(req.body, name, domain, req, res, targetDomain);
 
   // get the followers JSON for the user
-  const oldFollowersText = (await apDb.getFollowers()) || "[]";
+  const oldFollowersText = (await apDb.getFollowers()) || '[]';
 
   // update followers
   let followers = parseJSON(oldFollowersText);
@@ -96,109 +89,84 @@ async function handleUnfollow(req, res) {
     const updatedFollowers = await apDb.setFollowers(newFollowersText);
     return res.sendStatus(200);
   } catch (e) {
-    console.log("error storing followers after unfollow", e);
+    console.log('error storing followers after unfollow', e);
     return res.status(500);
   }
 }
 
 async function handleFollowAccepted(req, res) {
-  const domain = req.app.get("domain");
-  const apDb = req.app.get("apDb");
+  const domain = req.app.get('domain');
+  const apDb = req.app.get('apDb');
 
-  const oldFollowingText = (await apDb.getFollowing()) || "[]";
+  const oldFollowingText = (await apDb.getFollowing()) || '[]';
 
-    let follows = parseJSON(oldFollowingText);
+  let follows = parseJSON(oldFollowingText);
 
-    if (follows) {
-      follows.push(req.body.actor);
-      // unique items
-      follows = [...new Set(follows)];
-    } else {
-      follows = [req.body.actor];
-    }
-    let newFollowingText = JSON.stringify(follows);
+  if (follows) {
+    follows.push(req.body.actor);
+    // unique items
+    follows = [...new Set(follows)];
+  } else {
+    follows = [req.body.actor];
+  }
+  let newFollowingText = JSON.stringify(follows);
 
-    try {
-      // update into DB
-      const newFollowing = await apDb.setFollowing(newFollowingText);
+  try {
+    // update into DB
+    const newFollowing = await apDb.setFollowing(newFollowingText);
 
-      console.log("updated following!");
-      return res.status(200);
-    } catch (e) {
-      console.log("error storing follows after follow action", e);
-      return res.status(500);
-    }
+    console.log('updated following!');
+    return res.status(200);
+  } catch (e) {
+    console.log('error storing follows after follow action', e);
+    return res.status(500);
+  }
 }
 
 async function handleCommentOnBookmark(req, res, inReplyToGuid) {
-  const apDb = req.app.get("apDb");
+  const apDb = req.app.get('apDb');
 
   const bookmarkId = await apDb.getBookmarkIdFromMessageGuid(inReplyToGuid);
 
-    if (typeof bookmarkId !== "number") {
-      console.log("couldn't find a bookmark this message is related to");
-      return res.sendStatus(400);
-    }
+  if (typeof bookmarkId !== 'number') {
+    console.log("couldn't find a bookmark this message is related to");
+    return res.sendStatus(400);
+  }
 
-    const bookmarkPermissions = await apDb.getPermissionsForBookmark(
-      bookmarkId
-    );
-    const globalPermissions = await apDb.getGlobalPermissions();
+  const bookmarkPermissions = await apDb.getPermissionsForBookmark(bookmarkId);
+  const globalPermissions = await apDb.getGlobalPermissions();
 
-    const bookmarkBlocks = bookmarkPermissions?.blocked?.split("\n") || [];
-    const globalBlocks = globalPermissions?.blocked?.split("\n") || [];
+  const bookmarkBlocks = bookmarkPermissions?.blocked?.split('\n') || [];
+  const globalBlocks = globalPermissions?.blocked?.split('\n') || [];
 
-    const bookmarkAllows = bookmarkPermissions?.allowed?.split("\n") || [];
-    const globalAllows = globalPermissions?.allowed?.split("\n") || [];
+  const bookmarkAllows = bookmarkPermissions?.allowed?.split('\n') || [];
+  const globalAllows = globalPermissions?.allowed?.split('\n') || [];
 
-    const blocklist = bookmarkBlocks
-      .concat(globalBlocks)
-      .filter((x) => x.match(/^@([^@]+)@(.+)$/));
-    const allowlist = bookmarkAllows
-      .concat(globalAllows)
-      .filter((x) => x.match(/^@([^@]+)@(.+)$/));
+  const blocklist = bookmarkBlocks.concat(globalBlocks).filter((x) => x.match(/^@([^@]+)@(.+)$/));
+  const allowlist = bookmarkAllows.concat(globalAllows).filter((x) => x.match(/^@([^@]+)@(.+)$/));
 
-    if (
-      blocklist.length > 0 &&
-      blocklist
-        .map((username) => actorMatchesUsername(req.body.actor, username))
-        .some((x) => x)
-    ) {
-      console.log(
-        `Actor ${req.body.actor} matches a blocklist item, ignoring comment`
-      );
-      return res.sendStatus(403);
-    }
+  if (blocklist.length > 0 && blocklist.map((username) => actorMatchesUsername(req.body.actor, username)).some((x) => x)) {
+    console.log(`Actor ${req.body.actor} matches a blocklist item, ignoring comment`);
+    return res.sendStatus(403);
+  }
 
   const response = await signedFetch(req.body.actor);
   const data = await response.json();
 
-    const actorDomain = new URL(req.body.actor)?.hostname;
-    const actorUsername = data.preferredUsername;
-    const actor = `@${actorUsername}@${actorDomain}`;
+  const actorDomain = new URL(req.body.actor)?.hostname;
+  const actorUsername = data.preferredUsername;
+  const actor = `@${actorUsername}@${actorDomain}`;
 
-    const commentUrl = req.body.object.id;
-    let visible = 0;
-    if (
-      allowlist
-        .map((username) => actorMatchesUsername(req.body.actor, username))
-        .some((x) => x)
-    ) {
-      console.log(
-        `Actor ${req.body.actor} matches an allowlist item, marking comment visible`
-      );
-      visible = 1;
-    }
+  const commentUrl = req.body.object.id;
+  let visible = 0;
+  if (allowlist.map((username) => actorMatchesUsername(req.body.actor, username)).some((x) => x)) {
+    console.log(`Actor ${req.body.actor} matches an allowlist item, marking comment visible`);
+    visible = 1;
+  }
 
-    const bookmarksDb = req.app.get("bookmarksDb");
+  const bookmarksDb = req.app.get('bookmarksDb');
 
-    bookmarksDb.createComment(
-      bookmarkId,
-      actor,
-      commentUrl,
-      req.body.object.content,
-      visible
-    );
+  bookmarksDb.createComment(bookmarkId, actor, commentUrl, req.body.object.content, visible);
 
   return res.status(200);
 }
@@ -218,15 +186,9 @@ async function handleFollowedPost(req, res) {
 
     const commentUrl = req.body.object.id;
 
-    const bookmarksDb = req.app.get("bookmarksDb");
+    const bookmarksDb = req.app.get('bookmarksDb');
 
-    bookmarksDb.createComment(
-      undefined,
-      actor,
-      commentUrl,
-      req.body.object.content,
-      false
-    );
+    bookmarksDb.createComment(undefined, actor, commentUrl, req.body.object.content, false);
   }
 
   return res.status(200);
@@ -235,7 +197,7 @@ async function handleFollowedPost(req, res) {
 async function handleDeleteRequest(req, res) {
   console.log(JSON.stringify(req.body));
 
-  const bookmarksDb = req.app.get("bookmarksDb");
+  const bookmarksDb = req.app.get('bookmarksDb');
 
   const commentId = req.body?.object?.id;
 
@@ -246,24 +208,22 @@ async function handleDeleteRequest(req, res) {
   return res.status(200);
 }
 
-router.post("/", async function (req, res) {
+router.post('/', async function (req, res) {
   // console.log(JSON.stringify(req.body));
 
-  if (typeof req.body.object === "string" && req.body.type === "Follow") {
+  if (typeof req.body.object === 'string' && req.body.type === 'Follow') {
     return await handleFollowRequest(req, res);
-  } else if (req.body.type === "Undo" && req.body.object?.type === "Follow") {
+  } else if (req.body.type === 'Undo' && req.body.object?.type === 'Follow') {
     return await handleUnfollow(req, res);
-  } else if (req.body.type === "Accept" && req.body.object?.type === "Follow") {
+  } else if (req.body.type === 'Accept' && req.body.object?.type === 'Follow') {
     return await handleFollowAccepted(req, res);
-  } else if (req.body.type === "Delete") {
+  } else if (req.body.type === 'Delete') {
     return await handleDeleteRequest(req, res);
-  } else if (req.body.type === "Create" && req.body.object?.type === "Note") {
+  } else if (req.body.type === 'Create' && req.body.object?.type === 'Note') {
     console.log(JSON.stringify(req.body));
 
-    const domain = req.app.get("domain");
-    const inReplyToGuid = req.body.object?.inReplyTo?.match(
-      `https://${domain}/m/(.+)`
-    )?.[1];
+    const domain = req.app.get('domain');
+    const inReplyToGuid = req.body.object?.inReplyTo?.match(`https://${domain}/m/(.+)`)?.[1];
 
     if (inReplyToGuid) {
       return handleCommentOnBookmark(req, res, inReplyToGuid);

--- a/src/routes/activitypub/inbox.js
+++ b/src/routes/activitypub/inbox.js
@@ -4,7 +4,7 @@ import * as linkify from 'linkifyjs';
 
 import { actorMatchesUsername, parseJSON } from '../../util.js';
 import { signAndSend, getInboxFromActorProfile } from '../../activitypub.js';
-import { signedFetch } from '../../signature.js';
+import { signedGetJSON } from '../../signature.js';
 
 export const router = express.Router();
 
@@ -150,7 +150,7 @@ async function handleCommentOnBookmark(req, res, inReplyToGuid) {
     return res.sendStatus(403);
   }
 
-  const response = await signedFetch(req.body.actor);
+  const response = await signedGetJSON(req.body.actor);
   const data = await response.json();
 
   const actorDomain = new URL(req.body.actor)?.hostname;
@@ -177,7 +177,7 @@ async function handleFollowedPost(req, res) {
     // store this for now
     // TODO: determine if the actor is in your current follow list!
 
-    const response = await signedFetch(`${req.body.actor}.json`);
+    const response = await signedGetJSON(`${req.body.actor}.json`);
     const data = await response.json();
 
     const actorDomain = new URL(req.body.actor)?.hostname;

--- a/src/routes/activitypub/inbox.js
+++ b/src/routes/activitypub/inbox.js
@@ -1,9 +1,10 @@
 import express from "express";
 import crypto from "crypto";
-import fetch from "node-fetch";
+import * as linkify from "linkifyjs";
+
 import { actorMatchesUsername, parseJSON } from "../../util.js";
 import { signAndSend, getInboxFromActorProfile } from "../../activitypub.js";
-import * as linkify from 'linkifyjs';
+import { signedFetch } from "../../signature.js";
 
 export const router = express.Router();
 
@@ -169,8 +170,8 @@ async function handleCommentOnBookmark(req, res, inReplyToGuid) {
       return res.sendStatus(403);
     }
 
-    const response = await fetch(req.body.actor);
-    const data = await response.json();
+  const response = await signedFetch(req.body.actor);
+  const data = await response.json();
 
     const actorDomain = new URL(req.body.actor)?.hostname;
     const actorUsername = data.preferredUsername;
@@ -208,7 +209,7 @@ async function handleFollowedPost(req, res) {
     // store this for now
     // TODO: determine if the actor is in your current follow list!
 
-    const response = await fetch(`${req.body.actor}.json`);
+    const response = await signedFetch(`${req.body.actor}.json`);
     const data = await response.json();
 
     const actorDomain = new URL(req.body.actor)?.hostname;

--- a/src/signature.js
+++ b/src/signature.js
@@ -1,8 +1,8 @@
-import crypto from "crypto";
-import fetch from "node-fetch";
+import crypto from 'crypto';
+import fetch from 'node-fetch';
 
-import { account, domain } from "./util.js";
-import { getPrivateKey } from "./activity-pub-db.js";
+import { account, domain } from './util.js';
+import { getPrivateKey } from './activity-pub-db.js';
 
 /**
  * Returns base-64 encoded SHA-256 digest of provided data
@@ -12,7 +12,7 @@ import { getPrivateKey } from "./activity-pub-db.js";
  * @returns {string}
  */
 function getDigest(data) {
-  return crypto.createHash("sha256").update(data).digest("base64");
+  return crypto.createHash('sha256').update(data).digest('base64');
 }
 
 /**
@@ -24,10 +24,10 @@ function getDigest(data) {
  * @returns {string}
  */
 function getSignature(privkey, data) {
-  const signer = crypto.createSign("sha256");
+  const signer = crypto.createSign('sha256');
   signer.update(data);
   signer.end();
-  return signer.sign(privkey).toString("base64");
+  return signer.sign(privkey).toString('base64');
 }
 
 /**
@@ -49,7 +49,7 @@ function getSignatureParams(body, method, url) {
   const dateParam = date.toUTCString();
 
   const params = {
-    "(request-target)": requestTarget,
+    '(request-target)': requestTarget,
     host: hostParam,
     date: dateParam,
   };
@@ -58,7 +58,7 @@ function getSignatureParams(body, method, url) {
   if (body) {
     const digest = getDigest(body);
     const digestParam = `SHA-256=${digest}`;
-    params["digest"] = digestParam;
+    params['digest'] = digestParam;
   }
 
   return params;
@@ -76,9 +76,9 @@ function getSignatureHeader(signature, signatureKeys) {
   return [
     `keyId="https://${domain}/u/${account}"`,
     `algorithm="rsa-sha256"`,
-    `headers="${signatureKeys.join(" ")}"`,
+    `headers="${signatureKeys.join(' ')}"`,
     `signature="${signature}"`,
-  ].join(",");
+  ].join(',');
 }
 
 /**
@@ -96,26 +96,24 @@ export async function signedFetch(url, init = {}) {
   }
 
   const { headers = {}, body = null, ...rest } = init;
-  const { method = body ? "POST" : "GET" } = init; // guess method if not provided
-  const isJSON = body && typeof body === "string"; // assume string body is JSON
+  const { method = body ? 'POST' : 'GET' } = init; // guess method if not provided
+  const isJSON = body && typeof body === 'string'; // assume string body is JSON
 
   const signatureParams = getSignatureParams(body, method, url);
   const signatureKeys = Object.keys(signatureParams);
   const stringToSign = Object.entries(signatureParams)
     .map(([k, v]) => `${k}: ${v}`)
-    .join("\n");
+    .join('\n');
   const signature = getSignature(privkey, stringToSign);
   const signatureHeader = getSignatureHeader(signature, signatureKeys);
 
-  const contentTypeHeader = isJSON
-    ? { "Content-Type": "application/json" }
-    : {};
+  const contentTypeHeader = isJSON ? { 'Content-Type': 'application/json' } : {};
 
   return fetch(url, {
     body,
     method,
     headers: {
-      Accept: "application/json",
+      Accept: 'application/json',
       ...contentTypeHeader,
       ...headers,
       Host: signatureParams.host,

--- a/src/signature.js
+++ b/src/signature.js
@@ -1,0 +1,128 @@
+import crypto from "crypto";
+import fetch from "node-fetch";
+
+import { account, domain } from "./util.js";
+import { getPrivateKey } from "./activity-pub-db.js";
+
+/**
+ * Returns base-64 encoded SHA-256 digest of provided data
+ *
+ * @param {string} data - UTF-8 string to be hashed
+ *
+ * @returns {string}
+ */
+function getDigest(data) {
+  return crypto.createHash("sha256").update(data).digest("base64");
+}
+
+/**
+ * Returns base-64 encoded string signed with user's RSA private key
+ *
+ * @param {string} privkey - Postmarks user's private key
+ * @param {string} data - UTF-8 string to sign
+ *
+ * @returns {string}
+ */
+function getSignature(privkey, data) {
+  const signer = crypto.createSign("sha256");
+  signer.update(data);
+  signer.end();
+  return signer.sign(privkey).toString("base64");
+}
+
+/**
+ * Returns object of params to be used for HTTP signature
+ *
+ * @param {BodyInit | null} [body] - Request body for signature digest (usually a JSON string, optional)
+ * @param {string} method - Request HTTP method name
+ * @param {string} url -
+ *
+ * @returns {Object}
+ */
+function getSignatureParams(body, method, url) {
+  const urlObj = new URL(url);
+  const path = `${urlObj.pathname}${urlObj.search}`;
+  const requestTarget = `${method.toLowerCase()} ${path}`;
+  const hostParam = urlObj.hostname;
+
+  const date = new Date();
+  const dateParam = date.toUTCString();
+
+  const params = {
+    "(request-target)": requestTarget,
+    host: hostParam,
+    date: dateParam,
+  };
+
+  // add digest param if request body is present
+  if (body) {
+    const digest = getDigest(body);
+    const digestParam = `SHA-256=${digest}`;
+    params["digest"] = digestParam;
+  }
+
+  return params;
+}
+
+/**
+ * Returns the full "Signature" header to be included in the signed request
+ *
+ * @param {string} signature - Base-64 encoded request signature
+ * @param {string[]} signatureKeys - Array of param names used when generating the signature
+ *
+ * @returns {string}
+ */
+function getSignatureHeader(signature, signatureKeys) {
+  return [
+    `keyId="https://${domain}/u/${account}"`,
+    `algorithm="rsa-sha256"`,
+    `headers="${signatureKeys.join(" ")}"`,
+    `signature="${signature}"`,
+  ].join(",");
+}
+
+/**
+ * Signs a fetch request with the account's RSA private key
+ *
+ * @param {URL | RequestInfo} url - URL (passed to fetch)
+ * @param {RequestInit} [init={}] - Optional fetch init object
+ *
+ * @returns {Promise<Response>}
+ */
+export async function signedFetch(url, init = {}) {
+  const privkey = await getPrivateKey(`${account}@${domain}`);
+  if (!privkey) {
+    throw new Error(`No private key found for ${account}.`);
+  }
+
+  const { headers = {}, body = null, ...rest } = init;
+  const { method = body ? "POST" : "GET" } = init; // guess method if not provided
+  const isJSON = body && typeof body === "string"; // assume string body is JSON
+
+  const signatureParams = getSignatureParams(body, method, url);
+  const signatureKeys = Object.keys(signatureParams);
+  const stringToSign = Object.entries(signatureParams)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join("\n");
+  const signature = getSignature(privkey, stringToSign);
+  const signatureHeader = getSignatureHeader(signature, signatureKeys);
+
+  const contentTypeHeader = isJSON
+    ? { "Content-Type": "application/json" }
+    : {};
+
+  return fetch(url, {
+    body,
+    method,
+    headers: {
+      Accept: "application/json",
+      ...contentTypeHeader,
+      ...headers,
+      Host: signatureParams.host,
+      Date: signatureParams.date,
+      Digest: signatureParams.digest,
+      Signature: signatureHeader,
+    },
+    ...rest,
+  });
+}


### PR DESCRIPTION
- Add signedFetch() utility function.
- Add signedGetJSON() and signedPostJSON() helper functions.
- Refactor signAndSend() function to use it.
- Replace calls to fetch() with signedGetJSON() or signedPostJSON() as needed.

Fixes #58 