### PR TITLE
Redirect /u/ and /m/ URLS for actor and messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 .glitchdotcom.json
 .node-gyp
 node_modules
-.data/*.db
+.data/*
+!.data/.keep
 .env
 .sqlite_history
 *.patch

--- a/src/pages/admin/data.hbs
+++ b/src/pages/admin/data.hbs
@@ -11,7 +11,8 @@
   <a href="/admin/activitypub.db">here</a>.
 </p>
 
-<form action="/admin/reset" method="post">
+<form action="/admin/reset" method="post"
+  onsubmit="return confirm('Last chance! This will DELETE ALL YOUR BOOKMARKS. Are you sure you want to do this?')">
   <h3>
     Delete all bookmarks
   </h3>

--- a/src/routes/activitypub/message.js
+++ b/src/routes/activitypub/message.js
@@ -15,6 +15,10 @@ router.get('/:guid', async (req, res) => {
     return res.status(404).send(`No message found for ${guid}.`);
   }
 
+  if (!req.headers.accept?.includes('json')) {
+    return res.redirect(`/bookmark/${result.bookmark_id}`);
+  }
+
   return res.json(JSON.parse(result.message));
 });
 

--- a/src/routes/activitypub/message.js
+++ b/src/routes/activitypub/message.js
@@ -9,14 +9,16 @@ router.get('/:guid', async (req, res) => {
   }
 
   const db = req.app.get('apDb');
+
+  if (!req.headers.accept?.includes('json')) {
+    const bookmarkId = await db.getBookmarkIdFromMessageGuid(guid);
+    return res.redirect(`/bookmark/${bookmarkId}`);
+  }
+
   const result = await db.getMessage(guid);
 
   if (result === undefined) {
     return res.status(404).send(`No message found for ${guid}.`);
-  }
-
-  if (!req.headers.accept?.includes('json')) {
-    return res.redirect(`/bookmark/${result.bookmark_id}`);
   }
 
   return res.json(JSON.parse(result.message));

--- a/src/routes/activitypub/user.js
+++ b/src/routes/activitypub/user.js
@@ -8,6 +8,10 @@ router.get('/:name', async (req, res) => {
   if (!name) {
     return res.status(400).send('Bad request.');
   }
+  if (!req.headers.accept?.includes('json')) {
+    return res.redirect('/');
+  }
+
   const db = req.app.get('apDb');
   const domain = req.app.get('domain');
   const username = name;


### PR DESCRIPTION
This will fix the problem where embeds on Mastodon posts, the "show original" link in many clients, and clicking on the username on the user profile on Mastodon were redirecting to a raw JSON page in your browser. We still respond with JSON when it's requested in various forms (I left it open-ended since other Postmarks instances aren't correctly requesting the LD version of JSON yet).

Closes #33.