### PR TITLE
Updated AP outbox generation. Closes #41.

### DIFF
--- a/src/activity-pub-db.js
+++ b/src/activity-pub-db.js
@@ -115,6 +115,14 @@ export async function getMessage(guid) {
   return db?.get('select message from messages where guid = ?', guid);
 }
 
+export async function getMessageCount() {
+  return (await db?.get('select count(message) as count from messages'))?.count;
+}
+
+export async function getMessages(offset = 0, limit = 20) {
+  return db?.all('select message from messages order by bookmark_id desc limit ? offset ?', limit, offset);
+}
+
 export async function findMessageGuid(bookmarkId) {
   return (await db?.get('select guid from messages where bookmark_id = ?', bookmarkId))?.guid;
 }

--- a/src/activitypub.js
+++ b/src/activitypub.js
@@ -239,3 +239,14 @@ export async function broadcastMessage(bookmark, action, db, account, domain) {
     }
   }
 }
+
+export function synthesizeActivity(note) {
+  return {
+    // Fake activity URI adds a "a-" prefix to the Note/message guid
+    id: note.id.replace('/m/', '/m/a-'),
+    type: 'Create',
+    published: note.published,
+    actor: note.attributedTo,
+    object: note,
+  };
+}

--- a/src/routes/activitypub/message.js
+++ b/src/routes/activitypub/message.js
@@ -1,9 +1,17 @@
 import express from 'express';
+import { synthesizeActivity } from '../../activitypub.js';
 
 const router = express.Router();
 
 router.get('/:guid', async (req, res) => {
-  const { guid } = req.params;
+  let { guid } = req.params;
+  let isActivity = false;
+
+  if (guid.startsWith('a-')) {
+    guid = guid.slice(2);
+    isActivity = true;
+  }
+
   if (!guid) {
     return res.status(400).send('Bad request.');
   }
@@ -21,7 +29,12 @@ router.get('/:guid', async (req, res) => {
     return res.status(404).send(`No message found for ${guid}.`);
   }
 
-  return res.json(JSON.parse(result.message));
+  let object = JSON.parse(result.message);
+  if (isActivity) {
+    object = synthesizeActivity(object);
+  }
+
+  return res.json(object);
 });
 
 export default router;


### PR DESCRIPTION
Creates synthetic Create activities, with stable URIs, to wrap note messages from the activitypub database. These synthetic activity URIs can also be dereferenced (in addition to directly dereferencing Notes/messages).

The synthetic activities are given a URI that's based on the Note/message URIs. During dereferencing, the route handler can determine if an Activity or Note is being requested and wrap the Note if the Activity was requested.

I changed the structure of the collection objects. I'm guessing that the previous structure may have been inspired by Example 20 of the AS2 specification. This is a confusing and misleading example for AP purposes. The new structure matches Figure 21 of the AS2 specification. There is an OrderedCollection with links to a series of OrderedCollectionPages with first, last, next, prev links. So, a query without a page specified will return the OrderedCollection and the page queries will return an OrderedCollectionPage. This is consistent with how Mastodon handles outbox queries. 