### PR TITLE
Fix timezone issues

### DIFF
--- a/src/bookmarks-db.js
+++ b/src/bookmarks-db.js
@@ -47,8 +47,15 @@ function addBookmarkDomain(bookmark) {
 }
 
 function insertRelativeTimestamp(object) {
+  // timestamps created by SQLite's CURRENT_TIMESTAMP are in UTC regardless
+  // of server setting, but don't actually indicate a timezone in the string
+  // that's returned. Had I known this, I probably would have avoided
+  // CURRENT_TIMESTAMP altogether, but since lots of people already have
+  // databases full of bookmarks, in lieu of a full-on migration to go along
+  // with a code change that sees JS-generated timestamps at the time of
+  // SQLite INSERTs, we can just append the UTC indicator to the string when parsing it.
   return {
-    timestamp: timeSince(new Date(object.created_at).getTime()),
+    timestamp: timeSince(new Date(`${object.created_at}Z`).getTime()),
     ...object,
   };
 }

--- a/src/pages/bookmarks-xml.hbs
+++ b/src/pages/bookmarks-xml.hbs
@@ -1,14 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
    <title>{{feedTitle}}</title>
-   <subtitle>{{TODO}}</subtitle>
    <link rel="self" href="{{projectUrl}}/index.xml"/>
-   <id>{{projectUrl}}</id>
+   <id>{{projectUrl}}/</id>
    <updated>{{last_updated}}</updated>
    <author>
       <name>{{account}}</name>
    </author>
-   <rights>{{TODO}}</rights>
 
    {{#each bookmarks }}
      <entry>
@@ -16,9 +14,11 @@
       <link rel="alternate" href="{{url}}"/>
       <id>{{projectUrl}}/bookmark/{{id}}</id>
       <updated>{{created_at}}</updated>
-      <summary type="html">{{description}}</summary>
+      {{#if description}}
+         <summary type="html">{{description}}</summary>
+      {{/if}}
       {{#each tag_array}}
-      <category term="{{this}}" scheme="postmarks:tag" />
+      <category term="{{this}}" />
       {{/each}}
    </entry>
   {{/each}}

--- a/src/routes/core.js
+++ b/src/routes/core.js
@@ -86,7 +86,7 @@ router.get('/index.xml', async (req, res) => {
   } else {
     params.bookmarks = bookmarks.map((bookmark) => {
       const tagArray = bookmark.tags?.split(' ').map((b) => b.slice(1)) ?? [];
-      const createdAt = new Date(bookmark.created_at);
+      const createdAt = new Date(`${bookmark.created_at}Z`);
       return {
         tag_array: tagArray,
         ...bookmark,

--- a/src/util.js
+++ b/src/util.js
@@ -37,8 +37,8 @@ export const instanceVersion = instanceData.version || 'undefined';
 
 export function timeSince(ms) {
   const timestamp = new Date(ms);
-  const now = new Date();
-  const secondsPast = (now.getTime() - timestamp) / 1000;
+  const now = new Date(new Date().toUTCString());
+  const secondsPast = (now - timestamp) / 1000;
   if (secondsPast < 60) {
     return `${parseInt(secondsPast, 10)}s ago`;
   }


### PR DESCRIPTION
So it turns out that SQLite is pretty extreme in assuming that your server's local time is in the UTC timezone, which is something I generally agree with as a best practice but understand cannot be guaranteed.

When we create bookmarks and comments we rely on SQLite to inject the `created_at` timestamp using the `CURRENT_TIMESTAMP` helper. This always stores the timestamp using UTC, translating from the system's local time if necessary, and then when you `SELECT` that field back out using the sqlite node package, you get... a string that doesn't have any kind of timezone attached to it. Javascript assumes that means the timestamp is in the local timezone, which it might not be, and if that's the case everything goes haywire.

This change takes the least-intrusive approach to fixing this by appending the letter 'Z' to the end of timestamps retrieved from the database in the places that we do that. It doesn't feel great but any alternatives I could think of this morning feel likely to cause a lot of pain for people with existing bookmarks databases. We'll just need to make sure that all new JS code that parses SQLite timestamps does the same.

This closes #59.