### PR TITLE
Add csv export for bookmarks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "chalk": "^5.2.0",
         "connect-sqlite3": "^0.9.13",
         "cors": "^2.8.5",
+        "csv-stringify": "^6.4.2",
         "dotenv": "^16.0.3",
         "es6-promisify": "^7.0.0",
         "express": "^4.18.2",
@@ -1196,6 +1197,11 @@
       "funding": {
         "url": "https://github.com/sponsors/fb55"
       }
+    },
+    "node_modules/csv-stringify": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.4.2.tgz",
+      "integrity": "sha512-DXIdnnCUQYjDKTu6TgCSzRDiAuLxDjhl4ErFP9FGMF3wzBGOVMg9bZTLaUcYtuvhXgNbeXPKeaRfpgyqE4xySw=="
     },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
@@ -7024,6 +7030,11 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
       "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw=="
+    },
+    "csv-stringify": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.4.2.tgz",
+      "integrity": "sha512-DXIdnnCUQYjDKTu6TgCSzRDiAuLxDjhl4ErFP9FGMF3wzBGOVMg9bZTLaUcYtuvhXgNbeXPKeaRfpgyqE4xySw=="
     },
     "data-uri-to-buffer": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "chalk": "^5.2.0",
     "connect-sqlite3": "^0.9.13",
     "cors": "^2.8.5",
+    "csv-stringify": "^6.4.2",
     "dotenv": "^16.0.3",
     "es6-promisify": "^7.0.0",
     "express": "^4.18.2",

--- a/src/bookmarks-db.js
+++ b/src/bookmarks-db.js
@@ -192,9 +192,12 @@ export async function getBookmarks(limit = 10, offset = 0) {
 export async function getBookmarksForCSVExport() {
   // We use a try catch block in case of db errors
   try {
-    const results = await db.all('SELECT title,url,description,tags,created_at,updated_at from bookmarks');
-    // These titles should be updated if the query changes above.
-    const columnTitles = { title: 'title', url: 'url', description: 'description', tags: 'tags', created_at: 'created_at', updated_at: 'updated_at' };
+    const headers = ['title', 'url', 'description', 'tags', 'created_at', 'updated_at'];
+    const selectHeaders = headers.join(',');
+    // This will create an object where the keys and values match. This will
+    // allow the csv stringifier to interpret this as a header row.
+    const columnTitles = Object.fromEntries(headers.map((header) => [header, header]));
+    const results = await db.all(`SELECT ${selectHeaders} from bookmarks`);
     return [columnTitles].concat(results);
   } catch (dbError) {
     // Database connection error

--- a/src/bookmarks-db.js
+++ b/src/bookmarks-db.js
@@ -192,11 +192,9 @@ export async function getBookmarks(limit = 10, offset = 0) {
 export async function getBookmarksForCSVExport() {
   // We use a try catch block in case of db errors
   try {
-    const results = await db.all(
-      'SELECT title,url,description,tags,created_at,updated_at from bookmarks',
-    );
+    const results = await db.all('SELECT title,url,description,tags,created_at,updated_at from bookmarks');
     // These titles should be updated if the query changes above.
-    const columnTitles = {'title': 'title','url': 'url','description': 'description','tags': 'tags','created_at': 'created_at','updated_at': 'updated_at'};
+    const columnTitles = { title: 'title', url: 'url', description: 'description', tags: 'tags', created_at: 'created_at', updated_at: 'updated_at' };
     return [columnTitles].concat(results);
   } catch (dbError) {
     // Database connection error

--- a/src/bookmarks-db.js
+++ b/src/bookmarks-db.js
@@ -189,6 +189,22 @@ export async function getBookmarks(limit = 10, offset = 0) {
   return undefined;
 }
 
+export async function getBookmarksForCSVExport() {
+  // We use a try catch block in case of db errors
+  try {
+    const results = await db.all(
+      'SELECT title,url,description,tags,created_at,updated_at from bookmarks',
+    );
+    // These titles should be updated if the query changes above.
+    const columnTitles = {'title': 'title','url': 'url','description': 'description','tags': 'tags','created_at': 'created_at','updated_at': 'updated_at'};
+    return [columnTitles].concat(results);
+  } catch (dbError) {
+    // Database connection error
+    console.error(dbError);
+  }
+  return undefined;
+}
+
 export async function getBookmarkCountForTags(tags) {
   const tagClauses = tags.map(() => `(tags like ? OR tags like ?)`).join(' AND ');
   const tagParams = tags.map((tag) => [`%${tag}% `, `%${tag}%`]).flat();

--- a/src/pages/admin/data.hbs
+++ b/src/pages/admin/data.hbs
@@ -1,10 +1,13 @@
 <h3>
   Download bookmarks
 </h3>
-<p>
-  You can download your bookmarks sqlite db
-  <a href="/admin/bookmarks.db">here</a>.
+<p style='margin: 0'>
+  You can download your bookmarks as:
 </p>
+  <ul>
+    <li><a href="/admin/bookmarks.db">sqlite database</a></li>
+    <li><a href="/admin/bookmarks.csv">csv</a></li>
+  </ul>
 <p>
   It's less likely you'll need this, but you can also download your
   activitypub.db

--- a/src/pages/admin/data.hbs
+++ b/src/pages/admin/data.hbs
@@ -1,7 +1,7 @@
 <h3>
   Download bookmarks
 </h3>
-<p style='margin: 0'>
+<p style="margin: 0;">
   You can download your bookmarks as:
 </p>
   <ul>

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -2,6 +2,7 @@ import express from 'express';
 import { domain, actorInfo, parseJSON } from '../util.js';
 import { isAuthenticated } from '../session-auth.js';
 import { lookupActorInfo, createFollowMessage, createUnfollowMessage, signAndSend, getInboxFromActorProfile } from '../activitypub.js';
+import { stringify as csvStringify } from 'csv-stringify/sync';
 
 const DATA_PATH = '/app/.data';
 
@@ -89,6 +90,17 @@ router.get('/bookmarks.db', isAuthenticated, async (req, res) => {
   res.setHeader('Content-Disposition', 'attachment; filename="bookmarks.db"');
 
   res.download(filePath);
+});
+
+router.get('/bookmarks.csv', isAuthenticated, async (req, res) => {
+  const bookmarksDb = req.app.get('bookmarksDb');
+  const bookmarks = await bookmarksDb.getBookmarksForCSVExport();
+  const result = csvStringify(bookmarks);
+
+  res.setHeader('Content-Type', 'text/csv');
+  res.setHeader('Content-Disposition', 'attachment; filename="bookmarks.csv"');
+
+  res.send(result);
 });
 
 router.get('/activitypub.db', isAuthenticated, async (req, res) => {

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -96,7 +96,7 @@ router.get('/bookmarks.db', isAuthenticated, async (req, res) => {
 router.get('/bookmarks.csv', isAuthenticated, async (req, res) => {
   const bookmarksDb = req.app.get('bookmarksDb');
   const bookmarks = await bookmarksDb.getBookmarksForCSVExport();
-  const result = csvStringify(bookmarks);
+  const result = csvStringify(bookmarks, { quoted: true });
 
   res.setHeader('Content-Type', 'text/csv');
   res.setHeader('Content-Disposition', 'attachment; filename="bookmarks.csv"');

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -1,8 +1,10 @@
 import express from 'express';
+/* eslint-disable import/no-unresolved, node/no-missing-import */
+import { stringify as csvStringify } from 'csv-stringify/sync'; // https://github.com/adaltas/node-csv/issues/323
+/* eslint-enable */
 import { domain, actorInfo, parseJSON } from '../util.js';
 import { isAuthenticated } from '../session-auth.js';
 import { lookupActorInfo, createFollowMessage, createUnfollowMessage, signAndSend, getInboxFromActorProfile } from '../activitypub.js';
-import { stringify as csvStringify } from 'csv-stringify/sync';
 
 const DATA_PATH = '/app/.data';
 

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -1,7 +1,6 @@
 import express from 'express';
-/* eslint-disable import/no-unresolved, node/no-missing-import */
+// eslint-disable-next-line import/no-unresolved, node/no-missing-import
 import { stringify as csvStringify } from 'csv-stringify/sync'; // https://github.com/adaltas/node-csv/issues/323
-/* eslint-enable */
 import { domain, actorInfo, parseJSON } from '../util.js';
 import { isAuthenticated } from '../session-auth.js';
 import { lookupActorInfo, createFollowMessage, createUnfollowMessage, signAndSend, getInboxFromActorProfile } from '../activitypub.js';


### PR DESCRIPTION
This PR may close #86 unless there are additional desired formats.

## Description
#86 describes a need to export the bookmarks into a friendlier format. This PR attempts to do that by creating a specific bookmarksDB function for that query and then using the csv-stringify package to send it to the client. This PR makes an additional small change to the admin/data template to export the formats as a list.

## Testing
- Go to /admin/data
- Click the csv option in the list
- Verify a properly formatted csv is downloaded

## Alternatives Considered
I started out trying to just rely on sqlite to do the export. If you get in the console you can run:
```
.headers on
.mode csv
```
and selects will come out as csv.

I was having an issue toggling those options on as part of the `db.all/exec/run`. I think we could probably remove the csv-stringify dependency altogether if we could rely on this instead.

FYI @ckolderup @andypiper 