### PR TITLE
Clean up markup

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1,12 +1,3 @@
-/******************************************************************************
-START Glitch hello-app default styles
-
-The styles in this section do some minimal CSS resets, set default fonts and
-colors, and handle the layout for our footer and "Remix on Glitch" button. If
-you're new to CSS they may seem a little complicated, but you can scroll down
-to this section's matching END comment to see page-specific styles.
-******************************************************************************/
-
 @font-face {
   font-family: 'Public Sans';
   src: url('/PublicSans-VariableFont_wght.ttf');
@@ -64,7 +55,6 @@ to this section's matching END comment to see page-specific styles.
   background-color: #d0fff1;
 }
 
-/* Navigation grid */
 .footer {
   display: flex;
   justify-content: space-between;
@@ -73,6 +63,10 @@ to this section's matching END comment to see page-specific styles.
   width: 100%;
   flex-wrap: wrap;
   border-top: 4px solid #fff;
+}
+
+.footer a {
+  display: flex;
 }
 
 .footer a:not(.btn--remix):link,
@@ -84,21 +78,19 @@ a:not(.btn--remix):visited {
   text-decoration: none;
   border-style: none;
 }
+
+.footer a:not(:first-child):not(.btn--remix):before {
+  content: " ";
+  display: block;
+  width: .125rem;
+  height: 1.25rem;
+  background: #000;
+  margin: 0 1rem;
+}
+
 .footer a:hover {
   background: var(--color-primary);
 }
-
-.footer .links {
-  padding: 0.5rem 1rem 1.5rem;
-  white-space: nowrap;
-}
-
-.divider {
-  padding: 0 1rem;
-}
-/******************************************************************************
-END Glitch hello-app default styles
-******************************************************************************/
 
 body {
   font-family: 'Public Sans', sans-serif;
@@ -261,6 +253,9 @@ p.error a:visited {
 .comment .top {
   color: #707070;
 }
+.comment .top .timestamp:before {
+  content: "• ";
+}
 
 .bookmark .description {
   margin-bottom: 10px;
@@ -270,12 +265,18 @@ p.error a:visited {
 .bookmark .bottom a {
   font-weight: normal;
 }
+
+.bookmark .bottom span ~ span:before {
+  content: "•";
+}
+
 .bookmark .tags {
   margin-bottom: 4px;
 }
 
 .bookmark .tags .tag {
   margin-right: 0.5rem;
+  white-space: nowrap;
 }
 
 .bookmark .tags .tag-op {
@@ -357,4 +358,25 @@ textarea {
 
 .search input[type='submit'] {
   margin-left: 0.5rem;
+}
+
+.bookmark-date + .bookmark-domain:before {
+  content: "• ";
+}
+
+.form-group:not(:last-child) {
+  margin-bottom: 1rem;
+}
+
+.form-group label {
+  display: block;
+  cursor: pointer;
+}
+
+.form-group summary label {
+  display: inline;
+}
+
+.pagination span + span:before {
+  content: " • ";
 }

--- a/src/pages/about.hbs
+++ b/src/pages/about.hbs
@@ -1,18 +1,23 @@
 {{#if actorInfo.disabled}}
   <p>
     This is a bookmarking site running on software called
-    <a href="https://github.com/ckolderup/postmarks">Postmarks</a>. It's
-    currently running in "standalone" mode, meaning it doesn't broadcast any
+    <a href="https://github.com/ckolderup/postmarks">Postmarks</a>. It’s
+    currently running in “standalone” mode, meaning it doesn't broadcast any
     activity to the rest of the internet via the ActivityPub protocol. You can
     still subscribe to new bookmarks using the
     <a href="/index.xml">Atom feed</a>, which any modern RSS/feed reader should
     support.
   </p>
 {{else}}
-  <div class="bio"><img class="avatar" src="{{actorInfo.avatar}}" /><p>
+  <div class="bio">
+    <img class="avatar" src="{{actorInfo.avatar}}" />
+    <p>
       {{actorInfo.description}}
-    </p></div>
-  <h2>Follow on the Fediverse</h2>
+    </p>
+  </div>
+  <h2>
+    Follow on the Fediverse
+  </h2>
   <div>
     <button
       class="btn"
@@ -21,18 +26,28 @@
     >
       @{{actorInfo.username}}@{{domain}}
     </button>
-    <p><small class="copy-actor-status">Click the code above to copy</small></p>
+    <p>
+      <small class="copy-actor-status">
+        Click the code above to copy
+      </small>
+    </p>
   </div>
 
   {{#section 'script'}}
     <script src="/copy-to-clipboard.js"></script>
   {{/section}}
 {{/if}}
-<p>Postmarks (in its default configuration) uses an edited version of Eynav
-  Raphael's
-  <a href="https://thenounproject.com/icon/postmark-stamp-928917/">"Postmark
-    Stamp"</a>
+<p>
+  Postmarks (in its default configuration) uses an edited version of Eynav
+  Raphael’s
+  <a href="https://thenounproject.com/icon/postmark-stamp-928917/">
+    “Postmark Stamp”
+  </a>
   icon from The Noun Project. It also makes use of free fonts including
-  <a href="http://iotic.com/averia/">Averia Sans</a>
+  <a href="http://iotic.com/averia/">
+    Averia Sans
+  </a>
   and
-  <a href="https://public-sans.digital.gov/">Public Sans</a>.</p>
+  <a href="https://public-sans.digital.gov/">
+    Public Sans</a>.
+  </p>

--- a/src/pages/add_bookmark.hbs
+++ b/src/pages/add_bookmark.hbs
@@ -4,5 +4,5 @@
   </h3>
   <div class="bookmark">
     {{> edit_bookmark bookmark=undefined }}
-    </div>
+  </div>
 </div>

--- a/src/pages/admin/bookmarks.hbs
+++ b/src/pages/admin/bookmarks.hbs
@@ -1,11 +1,13 @@
 <h3>Mass upload bookmarks</h3>
 <p>
-  Input a collection of URLs, one on each line. They'll all be imported and
+  Input a collection of URLs, one on each line. They’ll all be imported and
   given a title and description where possible. You can go and edit them each
-  individually afterwards to add tags, different descriptions, etc.<br />
+  individually afterwards to add tags, different descriptions, etc.
+</p>
+<p>
   <b>Note:</b>
-  These won't post as ActivityPub Notes! This is just to quickly seed a set of
-  bookmarks. If you'll want comments on these, you'll have to update them
+  These won’t post as ActivityPub Notes! This is just to quickly seed a set of
+  bookmarks. If you’ll want comments on these, you’ll have to update them
   individually.
 </p>
 <form action="/bookmark/multiadd" method="post">

--- a/src/pages/admin/followers.hbs
+++ b/src/pages/admin/followers.hbs
@@ -7,11 +7,27 @@
   a per-bookmark setting on the bookmark edit page.
 </p>
 <form action="/admin/permissions" method="post">
-  <label> Auto-allow comments from (one username per line)</label><br />
-  <textarea name="allowed">{{allowed}}</textarea><br /><br />
-  <label> Auto-ignore comments from (one username per line)</label><br />
-  <textarea name="blocked">{{blocked}}</textarea>
-  <button type="submit">Save</button>
+  <div class="form-group">
+    <label for="permissions_allowed">
+      Auto-allow comments from (one username per line)
+    </label>
+    <textarea
+      id="permissions_allowed"
+      name="allowed"
+    >{{allowed}}</textarea>
+  </div>
+  <div class="form-group">
+    <label for="permissions_blocked">
+      Auto-ignore comments from (one username per line)
+    </label>
+    <textarea
+      id="permissions_blocked"
+      name="blocked"
+    >{{blocked}}</textarea>
+  </div>
+  <div class="form-group">
+    <button type="submit">Save</button>
+  </div>
 </form>
 
 <h3>

--- a/src/pages/admin/following.hbs
+++ b/src/pages/admin/following.hbs
@@ -4,7 +4,9 @@
 
 <div>
   <form action="/admin/following/follow" method="POST">
-    <label for="actor">Enter username to follow</label>
+    <label for="actor">
+      Enter username to follow
+    </label>
     <input
       type="text"
       id="actor"
@@ -21,7 +23,9 @@
   {{#each following}}
     <div class="following">
       <div class="info">
-        <a href="{{this}}">{{this}}</a>
+        <a href="{{this}}">
+          {{this}}
+        </a>
       </div>
       <div class="actions">
         <form action="/admin/following/unfollow" method="POST">

--- a/src/pages/bookmark.hbs
+++ b/src/pages/bookmark.hbs
@@ -1,10 +1,8 @@
 {{> show_bookmark bookmark=bookmark }}
 
 <h2>Comments</h2>
-{{#if comments }}
-  {{#each comments }}
-    {{> show_comment comment=this }}
-  {{/each}}
+{{#each comments }}
+  {{> show_comment comment=this }}
 {{else }}
   No comments yet!
-{{/if}}
+{{/each}}

--- a/src/pages/bookmarks-xml.hbs
+++ b/src/pages/bookmarks-xml.hbs
@@ -1,25 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
-   <title>{{feedTitle}}</title>
-   <link rel="self" href="{{projectUrl}}/index.xml"/>
-   <id>{{projectUrl}}/</id>
-   <updated>{{last_updated}}</updated>
-   <author>
-      <name>{{account}}</name>
-   </author>
-
-   {{#each bookmarks }}
-     <entry>
+  <title>{{feedTitle}}</title>
+  <link rel="self" href="{{projectUrl}}/index.xml"/>
+  <id>{{projectUrl}}/</id>
+  <updated>{{last_updated}}</updated>
+  <author>
+    <name>{{account}}</name>
+  </author>
+  {{#each bookmarks}}
+    <entry>
       <title>{{title}}</title>
       <link rel="alternate" href="{{url}}"/>
       <id>{{projectUrl}}/bookmark/{{id}}</id>
       <updated>{{created_at}}</updated>
       {{#if description}}
-         <summary type="html">{{description}}</summary>
+        <summary type="html">{{description}}</summary>
       {{/if}}
       {{#each tag_array}}
-      <category term="{{this}}" />
+        <category term="{{this}}" />
       {{/each}}
-   </entry>
+    </entry>
   {{/each}}
 </feed>

--- a/src/pages/edit_bookmark.hbs
+++ b/src/pages/edit_bookmark.hbs
@@ -1,24 +1,21 @@
 {{#unless creating}}
-<p>
-  <a href="/bookmark/{{bookmark.id}}"> ← Back to viewing</a>
-</p>
+  <p>
+    <a href="/bookmark/{{bookmark.id}}"> ← Back to viewing</a>
+  </p>
 {{/unless}}
 
+{{> edit_bookmark}}
 
-{{> edit_bookmark }}
-
-{{#unless creating }}
+{{#unless creating}}
   <h2>Review comments</h2>
-  {{#if comments }}
-    {{#each comments }}
-      {{> show_comment comment=this admin=true}}
-    {{/each}}
+  {{#each comments}}
+    {{> show_comment comment=this admin=true}}
   {{else}}
     No comments yet!
-  {{/if}}
+  {{/each}}
 {{/unless}}
 
-{{#unless creating }}
+{{#unless creating}}
   <h2>
     The Danger Zone
   </h2>
@@ -38,9 +35,9 @@
 
 
 <datalist id="all-tags">
-{{#each tags}}
-  <option value="{{this}}"/>
-{{/each}}
+  {{#each tags}}
+    <option value="{{this}}"/>
+  {{/each}}
 </datalist>
 
 {{#section 'script'}}

--- a/src/pages/layouts/admin.hbs
+++ b/src/pages/layouts/admin.hbs
@@ -1,68 +1,54 @@
 <html lang="en">
-
-<head>
-  <meta charset="utf-8" />
-  <link rel="icon" href="https://glitch.com/favicon.ico" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  {{{feedLink}}}
-
-  <title>{{title}} | {{siteName}}</title>
-
-  <link rel="apple-touch-icon" sizes="180x180"
-    href="https://cdn.glitch.global/8eaf209c-2fa9-4353-9b99-e8d8f3a5f8d4/postmarks-touch-icon-180.png?v=1693611327251" />
-  <link rel="shortcut icon"
-    href="https://cdn.glitch.global/8eaf209c-2fa9-4353-9b99-e8d8f3a5f8d4/postmarks-favicon.ico?v=1693611323474" />
-
-  <!-- Import the webpage's stylesheet -->
-  <link rel="stylesheet" href="/style.css" />
-
-</head>
-
-<body>
-  <div class="header">
-    <div class="logo"><img src="/postmarks-logo-small.png" /></div>
-    <div class="title">
-      <h1><a href="/">{{siteName}}</a></h1>
-    </div>
-    <div class="menu">
-      <a href="/about">About</a>
-      <a href="/bookmark/new">Add</a>
-      {{#if loggedIn}}
-      <a href="/admin">Admin</a>
-      <a href="/logout">Logout</a>
-      {{else}}
-      <a href="/login">Login</a>
-      {{/if}}
-    </div>
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="https://glitch.com/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    {{{feedLink}}}
+    <title>{{title}} | {{siteName}}</title>
+    <link rel="apple-touch-icon" sizes="180x180" href="https://cdn.glitch.global/8eaf209c-2fa9-4353-9b99-e8d8f3a5f8d4/postmarks-touch-icon-180.png?v=1693611327251" />
+    <link rel="shortcut icon" href="https://cdn.glitch.global/8eaf209c-2fa9-4353-9b99-e8d8f3a5f8d4/postmarks-favicon.ico?v=1693611323474" />
+    <link rel="stylesheet" href="/style.css" />
+  </head>
+  <body>
+    <div class="header">
+      <div class="logo">
+        <img src="/postmarks-logo-small.png" />
+      </div>
+      <div class="title">
+        <h1><a href="/">{{siteName}}</a></h1>
+      </div>
+      <div class="menu">
+        <a href="/about">About</a>
+        <a href="/bookmark/new">Add</a>
+        {{#if loggedIn}}
+          <a href="/admin">Admin</a>
+          <a href="/logout">Logout</a>
+        {{else}}
+          <a href="/login">Login</a>
+        {{/if}}
+      </div>
     </div>
     <div class="wrapper">
-    {{> admin_subnav }}
-    <div class="content" role="main">
-      <h2>{{title}}</h2>
-      {{{body}}}
+      {{> admin_subnav }}
+      <div class="content" role="main">
+        <h2>{{title}}</h2>
+        {{{body}}}
+      </div>
     </div>
-    </div>
-    <!-- The footer holds our remix button — you can use it for structure or cut it out ✂ -->
-  <footer class="footer">
-    <div class="links"></div>
-    <a href="/">Home</a>
-    <span class="divider">|</span>
-    {{#if loggedIn}}
-    <a href="/bookmark/new">Add</a>
-    <span class="divider">|</span>
-    <a href="/admin">Admin</a>
-    <span class="divider">|</span>
-    <a href="/logout">Logout</a>
-    {{else}}
-    <a href="/login">Login</a>
-    {{/if}}
-
-    <a class="btn--remix" target="_top" href="https://glitch.new/github.com/ckolderup/postmarks">
-      <img src="https://cdn.glitch.com/605e2a51-d45f-4d87-a285-9410ad350515%2FLogo_Color.svg?v=1618199565140" alt="" />
-      Remix on Glitch
-    </a>
-  </footer>
-  {{{_sections.script}}}
-</body>
-
+    <footer class="footer">
+      <a href="/">Home</a>
+      {{#if loggedIn}}
+        <a href="/bookmark/new">Add</a>
+        <a href="/admin">Admin</a>
+        <a href="/logout">Logout</a>
+      {{else}}
+        <a href="/login">Login</a>
+      {{/if}}
+      <a class="btn--remix" target="_top" href="https://glitch.new/github.com/ckolderup/postmarks">
+        <img src="https://cdn.glitch.com/605e2a51-d45f-4d87-a285-9410ad350515%2FLogo_Color.svg?v=1618199565140" alt="" />
+        Remix on Glitch
+      </a>
+    </footer>
+    {{{_sections.script}}}
+  </body>
 </html>

--- a/src/pages/layouts/main.hbs
+++ b/src/pages/layouts/main.hbs
@@ -1,27 +1,22 @@
 <html lang="en">
-
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="https://glitch.com/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    {{#if (mastodonAccount) }}
-    <link rel="me" href="{{ mastodonAccount }}" />
+    {{#if mastodonAccount}}
+      <link rel="me" href="{{ mastodonAccount }}" />
     {{/if}}
     {{{feedLink}}}
-
     <title>{{title}} | {{siteName}}</title>
-
     <link rel="apple-touch-icon" sizes="180x180" href="https://cdn.glitch.global/8eaf209c-2fa9-4353-9b99-e8d8f3a5f8d4/postmarks-touch-icon-180.png?v=1693611327251" />
     <link rel="shortcut icon" href="https://cdn.glitch.global/8eaf209c-2fa9-4353-9b99-e8d8f3a5f8d4/postmarks-favicon.ico?v=1693611323474" />
-
-    <!-- Import the webpage's stylesheet -->
     <link rel="stylesheet" href="/style.css" />
-
   </head>
-
   <body>
     <div class="header">
-      <div class="logo"><img src="/postmarks-logo-small.png" /></div>
+      <div class="logo">
+        <img src="/postmarks-logo-small.png" />
+      </div>
       <div class="title">
         <h1><a href="/">{{siteName}}</a></h1>
       </div>
@@ -33,45 +28,36 @@
           <a href="/bookmark/new">Add</a>
           <a href="/admin">Admin</a>
           <a href="/logout">Logout</a>
-          {{else}}
+        {{else}}
           <a href="/login">Login</a>
-          {{/if}}
+        {{/if}}
       </div>
     </div>
     <div class="wrapper">
-    {{> tag_list tags=tags}}
-    <div class="content" role="main">
-      <h2>{{title}}</h2>
-    {{{body}}}
+      {{> tag_list tags=tags}}
+      <div class="content" role="main">
+        <h2>{{title}}</h2>
+        {{{body}}}
       </div>
     </div>
-    <!-- The footer holds our remix button — you can use it for structure or cut it out ✂ -->
-  <footer class="footer">
-    <div class="links"></div>
-    <a href="/">Home</a>
-    <span class="divider">|</span>
-    <a href="/about">About</a>
-    <span class="divider">|</span>
-    <a href="/search">Search</a>
-    <span class="divider">|</span>
-    {{#if loggedIn}}
-    <a href="/network">Network</a>
-    <span class="divider">|</span>
-    <a href="/bookmark/new">Add</a>
-    <span class="divider">|</span>
-      <a href="/admin">Admin</a>
-      <span class="divider">|</span>
-      <a href="/logout">Logout</a>
+    <footer class="footer">
+      <a href="/">Home</a>
+      <a href="/about">About</a>
+      <a href="/search">Search</a>
+      {{#if loggedIn}}
+        <a href="/network">Network</a>
+        <a href="/bookmark/new">Add</a>
+        <a href="/admin">Admin</a>
+        <a href="/logout">Logout</a>
       {{else}}
-      <a href="/login">Login</a>
+        <a href="/login">Login</a>
       {{/if}}
-
-    <a class="btn--remix" target="_top" href="https://glitch.new/github.com/ckolderup/postmarks">
-      <img src="https://cdn.glitch.com/605e2a51-d45f-4d87-a285-9410ad350515%2FLogo_Color.svg?v=1618199565140"
-        alt="" />
-      Remix on Glitch
-    </a>
-  </footer>
-  {{{_sections.script}}}
+      <a class="btn--remix" target="_top" href="https://glitch.new/github.com/ckolderup/postmarks">
+        <img src="https://cdn.glitch.com/605e2a51-d45f-4d87-a285-9410ad350515%2FLogo_Color.svg?v=1618199565140"
+          alt="" />
+        Remix on Glitch
+      </a>
+    </footer>
+    {{{_sections.script}}}
   </body>
 </html>

--- a/src/pages/login.hbs
+++ b/src/pages/login.hbs
@@ -1,8 +1,12 @@
 <div class="login">
   <form method="POST" action="/login">
-    <label for="password">Password</label>
-    <input type="password" id="password" name="password" />
-    <input type="hidden" name="sendTo" value={{sendTo}} />
-    <button type="submit">Log in</button>
+    <div class="form-group">
+      <label for="password">Password</label>
+      <input type="password" id="password" name="password" />
+    </div>
+    <div class="form-group">
+      <input type="hidden" name="sendTo" value="{{sendTo}}" />
+      <button type="submit">Log in</button>
+    </div>
   </form>
 </div>

--- a/src/pages/network.hbs
+++ b/src/pages/network.hbs
@@ -8,16 +8,16 @@
         {{{this.content}}}
       </div>
       <div class="network-post-credit">
-        by
-        {{this.name}}
+        by {{this.name}}
       </div>
       <div class="network-post-links">
-        <a
-          href="/bookmark/new?url={{this.href}}&via={{this.url}}"
-        >(Quickadd)</a>
-        <a href="{{this.url}}">(Permalink)</a>
+        <a href="/bookmark/new?url={{this.href}}&via={{this.url}}">
+          (Quickadd)
+        </a>
+        <a href="{{this.url}}">
+          (Permalink)
+        </a>
       </div>
-
     </div>
   {{/each}}
 </div>

--- a/src/pages/nonfederated.hbs
+++ b/src/pages/nonfederated.hbs
@@ -1,9 +1,9 @@
 <div>
   <h3>Not enabled</h3>
   <p>
-    This feature is currently not enabled as it appears you don't have this app
-    set up to run on the fediverse. If you think that's incorrect, go back to
-    the setup instructions and make sure you've followed the necessary steps to
+    This feature is currently not enabled as it appears you don’t have this app
+    set up to run on the fediverse. If you think that’s incorrect, go back to
+    the setup instructions and make sure you’ve followed the necessary steps to
     create an identity.
   </p>
 </div>

--- a/src/pages/partials/edit_bookmark.hbs
+++ b/src/pages/partials/edit_bookmark.hbs
@@ -3,45 +3,91 @@
     action="/bookmark/{{bookmark.id}}?ephemeral={{ephemeral}}"
     method="POST"
   >
-    <label> URL </label><br />
-    <input type="text" name="url" value="{{bookmark.url}}" /><br />
-    <p>
-      <label> Title </label><br />
-      <input type="text" name="title" value="{{bookmark.title}}" /><br />
-      <label> Description </label><br />
-      <textarea name="description">{{bookmark.description}}</textarea><br />
-      <label> Tags </label><br />
-      <label class="small">press tab to autocomplete, press comma or enter to
-        save a new tag.</label>
-      <input id="tagEntry" type="text" list="all-tags" />
+    <div class="form-group">
+      <label for="bookmark_url">
+        URL
+      </label>
+      <input
+        id="bookmark_url"
+        type="text"
+        name="url"
+        value="{{bookmark.url}}"
+      />
+    </div>
+    <div class="form-group">
+      <label for="bookmark_title">
+        Title
+      </label>
+      <input
+        id="bookmark_title"
+        type="text"
+        name="title"
+        value="{{bookmark.title}}"
+      />
+    </div>
+      <label for="bookmark_description">
+        Description
+      </label>
+      <textarea
+        id="bookmark_description"
+        name="description"
+      >{{bookmark.description}}</textarea>
+    </div>
+    <div class="form-group">
+      <label for="tagEntry">
+        Tags
+        <small>
+          press tab to autocomplete, press comma or enter to save a new tag.
+        </small>
+      </label>
+      <input
+        id="tagEntry"
+        type="text"
+        list="all-tags"
+      />
       <div id="taggedList"></div>
-      <label class="small">click on a tag above to remove it</label>
+      <p>
+        <small>
+          click on a tag above to remove it
+        </small>
+      </p>
       <input
         type="hidden"
         id="tags"
         name="tags"
         value="{{{bookmark.tagsArray}}}"
       />
-    </p><br /><br />
-    <p>
-      <details>
-        <summary><label>
-            Auto-allow comments from (one username per line)</label></summary>
-        <textarea name="allowed">{{allowed}}</textarea>
-      </details>
-      <br /><br />
-      <details>
-        <summary><label>
-            Auto-ignore comments from (one username per line)</label></summary>
-        <textarea name="blocked">{{blocked}}</textarea>
-      </details>
-    </p>
-    <button type="submit">
-      {{#if bookmark}}
-        Save
-      {{else}}
-        Create
-      {{/if}}
-    </button>
+    </div>
+    <details class="form-group">
+      <summary>
+        <label for="bookmark_allowed">
+          Auto-allow comments from (one username per line)
+        </label>
+      </summary>
+      <textarea
+        id="bookmark_allowed"
+        name="allowed"
+      >{{allowed}}</textarea>
+    </details>
+    <details class="form-group">
+      <summary>
+        <label for="bookmark_blocked">
+          Auto-ignore comments from (one username per line)
+        </label>
+      </summary>
+      <textarea
+        id="bookmark_blocked"
+        name="blocked"
+      >{{blocked}}</textarea>
+    </details>
+    <div class="form-group">
+      <button type="submit">
+        {{#if bookmark}}
+          Save
+        {{else}}
+          Create
+        {{/if}}
+      </button>
+    </div>
   </form>
 </div>

--- a/src/pages/partials/pagination.hbs
+++ b/src/pages/partials/pagination.hbs
@@ -1,15 +1,25 @@
 {{#with pageInfo}}
-<div class="pagination">
+  <div class="pagination">
     {{#if hasPreviousPage }}
-      <a href="{{url}}?offset={{previousOffset}}">Previous</a>
+      <a href="{{url}}?offset={{previousOffset}}">
+        Previous
+      </a>
     {{else}}
-      Previous
+      <span>
+        Previous
+      </span>
     {{/if}}
-    • Page {{currentPage}} of {{totalPages}} •
-    {{#if hasNextPage }}
-      <a href="{{../url}}?offset={{nextOffset}}">Next</a>
+    <span>
+      Page {{currentPage}} of {{totalPages}}
+    </span>
+    {{#if hasNextPage}}
+      <a href="{{../url}}?offset={{nextOffset}}">
+        Next
+      </a>
     {{else}}
-      Next
+      <span>
+        Next
+      </span>
     {{/if}}
-</div>
+  </div>
 {{/with}}

--- a/src/pages/partials/show_bookmark.hbs
+++ b/src/pages/partials/show_bookmark.hbs
@@ -1,48 +1,64 @@
 <div class="bookmark">
   <div class="headline">
-    <a href="{{bookmark.url}}">{{bookmark.title}}</a>
+    <a href="{{bookmark.url}}">
+      {{bookmark.title}}
+    </a>
   </div>
   <div class="subhead">
-    <span title="{{bookmark.created_at}}">{{bookmark.timestamp}}</span>
-    •
-    {{bookmark.domain}}
+    <span class="bookmark-date" title="{{bookmark.created_at}}">
+      {{bookmark.timestamp}}
+    </span>
+    <span class="bookmark-domain">
+      {{bookmark.domain}}
+    </span>
   </div>
   <div class="description">
     {{{htmlize bookmark.description}}}
   </div>
   <div class="tags">
-    {{#if tagged }}
+    {{#if tagged}}
       {{#each bookmark.tagNames}}
-          {{#ifIn this @root.pathTags~}}
-            <span class="tag tag-disabled">#{{this}}
-            {{~#ifThisTag this @root.path }}
-            {{~else}}&nbsp;<a href="{{removeTag this @root.path}}" class="tag-op tag-remove">-</a>
-            {{/ifThisTag~}}
-            </span>
-          {{else~}}
-            <span class="tag"><a href="/tagged/{{this}}">#{{this}}</a>&nbsp;<a href="{{@root.path}}/{{this}}" class="tag-op tag-add">+</a></span>
-          {{/ifIn}}
-        {{/each}}
+        {{#ifIn this @root.pathTags}}
+          <span class="tag tag-disabled">
+            #{{this}}
+            {{^ifThisTag this @root.path}}
+              <a href="{{removeTag this @root.path}}" class="tag-op tag-remove">
+                -
+              </a>
+            {{/ifThisTag}}
+          </span>
+        {{else}}
+          <span class="tag">
+            <a href="/tagged/{{this}}">#{{this}}</a>
+            <a href="{{@root.path}}/{{this}}" class="tag-op tag-add">
+              +
+            </a>
+          </span>
+        {{/ifIn}}
+      {{/each}}
     {{else}}
       {{#each bookmark.tagNames}}
-        <span class="tag"><a href="/tagged/{{this}}">#{{this}}</a></span>
+        <span class="tag">
+          <a href="/tagged/{{this}}">
+            #{{this}}
+          </a>
+        </span>
       {{/each}}
     {{/if}}
   </div>
   <div class="bottom">
-    {{#if bookmark.comment_count includeZero=true}}
+    <span>
       <a href="/bookmark/{{bookmark.id}}">
         {{bookmark.comment_count}}
         {{pluralize bookmark.comment_count "comment" "comments"}}
       </a>
-    {{/if}}
+    </span>
     {{#if @root.loggedIn}}
-      {{#if bookmark.comment_count includeZero=true}}
-        •
-      {{/if}}
-    {{/if}}
-    {{#if @root.loggedIn}}
-      <a href="/bookmark/{{bookmark.id}}/edit">edit</a>
+      <span>
+        <a href="/bookmark/{{bookmark.id}}/edit">
+          edit
+        </a>
+      </span>
     {{/if}}
   </div>
 </div>

--- a/src/pages/partials/show_comment.hbs
+++ b/src/pages/partials/show_comment.hbs
@@ -1,11 +1,14 @@
 <div class="comment">
   <div class="top">
-    <strong>{{{comment.linked_display_name}}}</strong>
-    •
+    <strong>
+      {{{comment.linked_display_name}}}
+    </strong>
     <span
       class="timestamp"
       title="{{comment.created_at}}"
-    >{{comment.timestamp}}</span>
+    >
+      {{comment.timestamp}}
+    </span>
   </div>
   <div class="content">
     {{comment.content}}

--- a/src/pages/search.hbs
+++ b/src/pages/search.hbs
@@ -1,16 +1,17 @@
 <div class="search">
-    <form action="/search">
-        <input name="query" value="{{keywords}}"><input type="submit" value="Search">
-    </form>
+  <form action="/search">
+    <input name="query" value="{{keywords}}">
+    <button>Search</button>
+  </form>
 </div>
 {{#if error}}
-<p class="error">
+  <p class="error">
     {{error}}
-</p>
+  </p>
 {{else}}
-<div class="bookmarks">
+  <div class="bookmarks">
     {{#each bookmarks }}
-    {{> show_bookmark bookmark=this }}
+      {{> show_bookmark bookmark=this }}
     {{/each}}
-</div>
+  </div>
 {{/if}}


### PR DESCRIPTION
Mostly removes some presentational markup that is better-suited for CSS, like bullets between links, with an eye toward more flexible CSS in the future. There are no visual changes in this PR.

Also includes some little Handlebars convenience edits. And I did a pass on markup whitespace because I couldn't help myself.