### PR TITLE
fix mastodon verification with this one weird trick

### DIFF
--- a/src/pages/layouts/main.hbs
+++ b/src/pages/layouts/main.hbs
@@ -3,7 +3,7 @@
     <meta charset="utf-8" />
     <link rel="icon" href="https://glitch.com/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    {{#if mastodonAccount}}
+    {{#if (mastodonAccount)}}
       <link rel="me" href="{{ mastodonAccount }}" />
     {{/if}}
     {{{feedLink}}}


### PR DESCRIPTION
I had a report on Mastodon that verification wasn't working; I looked into it and noticed that since I last saw it working myself that these parentheses had been removed from the main.hbs (reasonable)

@johnholdun do you have some idea why they'd be required? I took a look through the Handlebars documentation and don't really "get it". Something to do with it being a helper function instead of a local var being passed into the render?