### PR TITLE
Adjusted SQL REGEX to fix bookmark search

### DIFF
--- a/server.js
+++ b/server.js
@@ -85,16 +85,17 @@ const hbs = create({
       return process.env.MASTODON_ACCOUNT;
     },
     ifIn(item, array, options) {
-      return array.indexOf(item) >= 0 ? options.fn(this) : options.inverse(this);
+      const lowercased = array.map((tag) => tag.toLowerCase());
+      return lowercased.indexOf(item.toLowerCase()) >= 0 ? options.fn(this) : options.inverse(this);
     },
     removeTag(tag, path) {
       return path
         .split('/')
-        .filter((x) => x !== tag)
+        .filter((x) => x.toLowerCase() !== tag.toLowerCase())
         .join('/');
     },
     ifThisTag(tag, path, options) {
-      return path === `/tagged/${tag}` ? options.fn(this) : options.inverse(this);
+      return path.toLowerCase() === `/tagged/${tag}`.toLowerCase() ? options.fn(this) : options.inverse(this);
     },
     eq(a, b, options) {
       return a === b ? options.fn(this) : options.inverse(this);

--- a/src/bookmarks-db.js
+++ b/src/bookmarks-db.js
@@ -215,7 +215,7 @@ export async function getBookmarksForCSVExport() {
 
 export async function getBookmarkCountForTags(tags) {
   const tagClauses = tags.map(() => `(tags like ? OR tags like ?)`).join(' AND ');
-  const tagParams = tags.map((tag) => [`%${tag}% `, `%${tag}%`]).flat();
+  const tagParams = tags.map((tag) => [`%#${tag} %`, `%#${tag}`]).flat();
   const result = await db.get.apply(db, [`SELECT count(id) as count from bookmarks WHERE ${tagClauses}`, ...tagParams]);
   return result?.count;
 }
@@ -224,7 +224,7 @@ export async function getBookmarksForTags(tags, limit = 10, offset = 0) {
   // We use a try catch block in case of db errors
   try {
     const tagClauses = tags.map(() => `(tags like ? OR tags like ?)`).join(' AND ');
-    const tagParams = tags.map((tag) => [`%${tag}% `, `%${tag}%`]).flat();
+    const tagParams = tags.map((tag) => [`%#${tag} %`, `%#${tag}`]).flat();
     const results = await db.all.apply(db, [
       `SELECT * from bookmarks WHERE ${tagClauses} ORDER BY updated_at DESC LIMIT ? OFFSET ?`,
       ...tagParams,


### PR DESCRIPTION
PR to fix #152 

Adjusted the REGEX for searching for tags
`%#${tag} %` - matches on tags that contain the tag name and has a space at the end, so searching for the ai tag would match if it was "#ai #smarthome #etc" and "#smarthome #ai #etc", but not "#air #smarthome #etc" or "#email #air #etc" (the previous version would have matched on 'air' or 'email' because they contain 'ai')

`%#${tag}` - handles matches for the final tag in the string, same rules as above but does not have a space at the end.

The 2nd part of this issue is a little more complicated and I wanted to get your advice before working on it. Specifically, with it not highlighting tags if capitalization doesn't match, I fixed it on my site by adding a toLowerCase helper to handlebars and applying it to anywhere where it links to /tagged/*tag* so that all url paths are lowercase
```javascript
    toLowerCase(a) {
      return a.toLowerCase();
    },
```
and then also changing ifIn and ifThisTag so that they compare ignoring the capitalization
```javascript
    ifIn(item, array, options) {
      const lowercased = array.map(tag => tag.toLowerCase());
      return lowercased.indexOf(item.toLowerCase()) >= 0 ? options.fn(this) : options.inverse(this);
    },
    
     ifThisTag(tag, path, options) {
      return path  === `/tagged/${tag}`.toLowerCase() ? options.fn(this) : options.inverse(this);
    },
```

I didn't know if it was best practice or if you had an opinion on throwing these `toLowerCase()` functions everywhere, it *feels* wrong but the other option *I think* involves just lowercasing the tag before it gets passed into any page (which I don't think would be right, as I'd expect we'd want to maintain the capitalization when showing the user the tags underneath the bookmark