### PR TITLE
feat: add nodeinfo 2.1 document (parallel with 2.0).

### DIFF
--- a/server.js
+++ b/server.js
@@ -125,5 +125,6 @@ app.use('/', routes.core);
 app.use('/api/inbox', cors(), routes.inbox);
 app.use('/.well-known/nodeinfo', routes.nodeinfo);
 app.use('/nodeinfo/2.0', routes.nodeinfo);
+app.use('/nodeinfo/2.1', routes.nodeinfo);
 
 app.listen(PORT, () => console.log(`App listening on port ${PORT}`));

--- a/src/routes/activitypub/nodeinfo.js
+++ b/src/routes/activitypub/nodeinfo.js
@@ -70,8 +70,8 @@ router.get('/', async (req, res) => {
       software: {
         name: instanceType,
         version: instanceVersion,
-        repository: "https://github.com/ckolderup/postmarks",
-        homepage: "https://postmarks.glitch.me",
+        repository: 'https://github.com/ckolderup/postmarks',
+        homepage: 'https://postmarks.glitch.me',
       },
       protocols: ['activitypub'],
       services: {
@@ -88,15 +88,14 @@ router.get('/', async (req, res) => {
       },
       openRegistrations: false,
       metadata: {
-        nodeName: "Postmarks",
-        nodeDescription: "A single-user bookmarking website designed to live on the Fediverse.",
+        nodeName: 'Postmarks',
+        nodeDescription: 'A single-user bookmarking website designed to live on the Fediverse.',
       },
     };
 
     res.type('application/json; profile="http://nodeinfo.diaspora.software/ns/schema/2.1#"');
     res.json(nodeInfo);
   }
-
 });
 
 export default router;

--- a/src/routes/activitypub/nodeinfo.js
+++ b/src/routes/activitypub/nodeinfo.js
@@ -1,4 +1,8 @@
-// implementation of http://nodeinfo.diaspora.software/protocol.html
+// implementation of http://nodeinfo.diaspora.software/
+// TODO: activeMonth and activeHalfyear should be dynamic, currently static
+// TODO: enable override of nodeName and nodeDescription from settings
+// homepage and repository may want to be updated for user-specific forks
+// NB openRegistrations will always be false for a single-instance server
 
 import express from 'express';
 import { instanceType, instanceVersion } from '../../util.js';
@@ -15,6 +19,10 @@ router.get('/', async (req, res) => {
           rel: 'http://nodeinfo.diaspora.software/ns/schema/2.0',
           href: `https://${domain}/nodeinfo/2.0`,
         },
+        {
+          rel: 'http://nodeinfo.diaspora.software/ns/schema/2.1',
+          href: `https://${domain}/nodeinfo/2.1`,
+        },
       ],
     };
     res.json(thisNode);
@@ -24,7 +32,6 @@ router.get('/', async (req, res) => {
     const bookmarksDb = req.app.get('bookmarksDb');
     const bookmarkCount = await bookmarksDb.getBookmarkCount();
 
-    // TODO: activeMonth and activeHalfyear should be dynamic, currently static
     const nodeInfo = {
       version: 2.0,
       software: {
@@ -48,12 +55,48 @@ router.get('/', async (req, res) => {
       metadata: {},
     };
 
-    // spec requires setting this, majority of implementations
-    // appear to not bother with it?
+    // spec says servers *should* set this, majority of implementations
+    // appear to not bother with this detail, but we'll do right by the spec
     res.type('application/json; profile="http://nodeinfo.diaspora.software/ns/schema/2.0#"');
-
     res.json(nodeInfo);
   }
+
+  if (req.originalUrl === '/nodeinfo/2.1') {
+    const bookmarksDb = req.app.get('bookmarksDb');
+    const bookmarkCount = await bookmarksDb.getBookmarkCount();
+
+    const nodeInfo = {
+      version: 2.1,
+      software: {
+        name: instanceType,
+        version: instanceVersion,
+        repository: "https://github.com/ckolderup/postmarks",
+        homepage: "https://postmarks.glitch.me",
+      },
+      protocols: ['activitypub'],
+      services: {
+        outbound: ['atom1.0'],
+        inbound: [],
+      },
+      usage: {
+        users: {
+          total: 1,
+          activeMonth: 1,
+          activeHalfyear: 1,
+        },
+        localPosts: bookmarkCount,
+      },
+      openRegistrations: false,
+      metadata: {
+        nodeName: "Postmarks",
+        nodeDescription: "A single-user bookmarking website designed to live on the Fediverse.",
+      },
+    };
+
+    res.type('application/json; profile="http://nodeinfo.diaspora.software/ns/schema/2.1#"');
+    res.json(nodeInfo);
+  }
+
 });
 
 export default router;


### PR DESCRIPTION
This PR updates Postmarks support for the [nodeinfo specification](https://nodeinfo.diaspora.software/) to include additional fields added in nodeinfo 2.1 (repository and project), as well as adding some optional metadata.

As a side-note, I also [sent a PR to the nodeinfo repository](https://github.com/jhass/nodeinfo/pull/87) to add Postmarks as a Fediverse server that implements the specification, as it has for some time now (albeit 2.0 level)