### PR TITLE
lint.yml: update to a supported node version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest # on which machine to run
     steps:
       - name: Install NodeJS
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
   
       - name: Code Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
   
       - name: Install Dependencies
         run: npm ci


### PR DESCRIPTION
This resolves the GH Actions warning that we are running on an outdated version of node / node has been updated to at least v16 (when running the linter task).