### PR TITLE
Add robotstxt

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest # on which machine to run
     steps:
       - name: Install NodeJS
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
   
       - name: Code Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
   
       - name: Install Dependencies
         run: npm ci

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,17 @@
+# See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
+
+User-agent: GPTBot
+Disallow: /
+
+User-agent: *
+Disallow: /api/inbox
+Disallow: /admin
+Disallow: /bookmark/
+Disallow: /comment
+Disallow: /login
+Disallow: /logout
+Disallow: /m/
+Disallow: /network
+Disallow: /search
+Disallow: /tagged/
+Disallow: /u/


### PR DESCRIPTION
Modelled on various other Fediverse software; there's generally no need for search engine robots to poke around inside a Postmarks instance, since it's going to be single-user specific. Particularly no need for them to attempt to hit the authenticated URLs.

Added as a static file to be served from the existing Express static config, for ease and simplicity.