### PR TITLE
remove seo.json

### DIFF
--- a/src/seo.json
+++ b/src/seo.json
@@ -1,7 +1,0 @@
-{
-  "title": "Postmarks",
-  "description": "An ActivityPub bookmarking and sharing site built with Glitch. Remix it to get your own.",
-  "url": "postmarks",
-  "image": "/postmarks-logo.png",
-  "db": "SQLite"
-}


### PR DESCRIPTION
It was pointed out in #179 that this file is just stranded in the repo, all references to it having been stripped out a while back but the file itself not getting deleted!