### PR TITLE
Add profile attachments (and a way of updating followers with new profile info)

### DIFF
--- a/account.json.example
+++ b/account.json.example
@@ -2,5 +2,12 @@
   "username": "bookmarks",
   "avatar": "https://cdn.glitch.global/8eaf209c-2fa9-4353-9b99-e8d8f3a5f8d4/postmarks-logo-white-small.png?v=1693610556689",
   "displayName": "Postmarks",
-  "description": "An ActivityPub bookmarking and sharing site built with Postmarks"
+  "description": "An ActivityPub bookmarking and sharing site built with Postmarks",
+  "attachment": [
+    {
+      "type": "PropertyValue",
+      "name": "Source Code",
+      "value": "<a href='https://github.com/ckolderup/postmarks' target='_blank' rel='nofollow noopener noreferrer me'>https://github.com/ckolderup/postmarks</a>"
+    }
+  ]
 }

--- a/src/activity-pub-db.js
+++ b/src/activity-pub-db.js
@@ -11,6 +11,7 @@ import sqlite3 from 'sqlite3';
 import { open } from 'sqlite';
 import crypto from 'crypto';
 import { account, domain, actorInfo } from './util.js';
+import { updateProfile } from './activitypub.js'
 
 const dbFile = './.data/activitypub.db';
 let db;
@@ -245,6 +246,7 @@ function setup() {
       const publicKey = await getPublicKey();
       const actorRecord = actorJson(publicKey);
       await db.run('UPDATE accounts SET name = ?, actor = ?', actorName, JSON.stringify(actorRecord));
+      //updateProfile(account, domain) // Uncomment this line to send a profile update to all followers
     } catch (dbError) {
       console.error(dbError);
     }

--- a/src/activity-pub-db.js
+++ b/src/activity-pub-db.js
@@ -16,7 +16,7 @@ import { updateProfile } from './activitypub.js'
 const dbFile = './.data/activitypub.db';
 let db;
 
-function actorJson(pubkey) {
+export function actorJson(pubkey) {
   return {
     '@context': ['https://www.w3.org/ns/activitystreams', 'https://w3id.org/security/v1'],
 
@@ -34,6 +34,7 @@ function actorJson(pubkey) {
     outbox: `https://${domain}/u/${account}/outbox`,
     followers: `https://${domain}/u/${account}/followers`,
     following: `https://${domain}/u/${account}/following`,
+    attachment: actorInfo.attachment,
 
     publicKey: {
       id: `https://${domain}/u/${account}#main-key`,

--- a/src/activitypub.js
+++ b/src/activitypub.js
@@ -4,6 +4,7 @@ import escapeHTML from 'escape-html';
 
 import { signedGetJSON, signedPostJSON } from './signature.js';
 import { actorInfo, actorMatchesUsername, replaceEmptyText } from './util.js';
+import * as apDb from './activity-pub-db.js'
 
 function getGuidFromPermalink(urlString) {
   return urlString.match(/(?:\/m\/)([a-zA-Z0-9+/]+)/)[1];
@@ -264,6 +265,36 @@ export async function broadcastMessage(bookmark, action, db, account, domain) {
       const targetDomain = myURL.host;
       signAndSend(message, account, domain, db, targetDomain, inbox);
     }
+  }
+}
+
+
+export async function updateProfile(account, domain) {
+  if (actorInfo.disabled) {
+    return; // no fediverse setup
+  }
+  const publicKey = await apDb.getPublicKey()
+  const actorRecord = apDb.actorJson(publicKey)
+  
+  const guidUpdate = crypto.randomBytes(16).toString('hex');
+  const updateMessage = {
+    '@context': ['https://www.w3.org/ns/activitystreams', 'https://w3id.org/security/v1'],
+    type: 'Update',
+    id: `https://${domain}/m/${guidUpdate}`,
+    actor: `https://${domain}/u/${account}`,
+    to: ['https://www.w3.org/ns/activitystreams#Public'],
+    object: actorRecord,
+  };
+  
+  apDb.insertMessage(guidUpdate, null, JSON.stringify(updateMessage));
+  const result = await apDb.getFollowers();
+  const followers = JSON.parse(result);
+  // eslint-disable-next-line no-restricted-syntax
+  for (const follower of followers) {
+      const myURL = new URL(follower);
+      const targetDomain = myURL.host;
+      const inbox = `https://${targetDomain}/inbox`;
+      signAndSend(updateMessage, account, domain, apDb, targetDomain, inbox);
   }
 }
 

--- a/src/pages/about.hbs
+++ b/src/pages/about.hbs
@@ -11,9 +11,21 @@
 {{else}}
   <div class="bio">
     <img class="avatar" src="{{actorInfo.avatar}}" />
-    <p>
-      {{actorInfo.description}}
-    </p>
+    <div>
+	    <p>
+	      {{{actorInfo.description}}}
+	    </p>
+	    <table class="attachments">
+	      <tbody>
+	        {{#each actorInfo.attachment}}
+	        <tr>
+	          <td>{{name}}: </td>
+              <td>{{{value}}}</td>
+            </tr>
+            {{/each}}
+          </tbody>
+        </table>
+    </div>
   </div>
   <h2>
     Follow on the Fediverse


### PR DESCRIPTION
Addresses #189 

I didn't add any styles to the new profile fields, so here's what they look like right now:
![image](https://github.com/ckolderup/postmarks/assets/7014115/a13cd8be-3c83-47ef-81b8-4409b1ebe976)

And then as of right now the only way I have to update current followers with this any new profile updates is to uncomment this line in activity-pub-db.js

` //updateProfile(account, domain) // Uncomment this line to send a profile update to all followers `

![image](https://github.com/ckolderup/postmarks/assets/7014115/3d4f9952-1a7c-4f2e-8ada-db7d7bc83563)


I have it commented it out by default because I assume we don't want send a message to every follower whenever the server boots up (and eventually I assume we'll have a way to update your profile from the admin page? In which case we'd just trigger updateProfile whenever that gets changed) 

Maybe this belongs in a different issue/feature request but I was thinking since we already have a variable for the mastodon account we could probably include that as a profile field by default if it exists

Lastly, I just noticed this as I was making this PR, in this current setup it adds up profile updates in the total post count, that gets fixed if I modify this function to:

```javascript
export async function getMessageCount() {
  return (await db?.get('select count(message) as count from messages where bookmark_id is not null'))?.count;
}
```

But I'd like clarification on if I'm storing these activities/updates in the right spot in the database or if there are any other non-bookmark activities that we are already storing