### PR TITLE
Changes to make WebFinger RFC-conformant

### DIFF
--- a/src/routes/activitypub/webfinger.js
+++ b/src/routes/activitypub/webfinger.js
@@ -5,16 +5,17 @@ const router = express.Router();
 router.get('/', async (req, res) => {
   const { resource } = req.query;
   if (!resource || !resource.includes('acct:')) {
-    return res.status(400).send('Bad request. Please make sure "acct:USER@DOMAIN" is what you are sending as the "resource" query parameter.');
+    return res.status(404).send('Not found. Please make sure "acct:USER@DOMAIN" is what you are sending as the "resource" query parameter.');
   }
 
   const name = resource.replace('acct:', '');
   const db = req.app.get('apDb');
   const webfinger = await db.getWebfinger();
-  if (webfinger === undefined) {
+  if (webfinger === undefined || webfinger.subject !== resource) {
     return res.status(404).send(`No webfinger record found for ${name}.`);
   }
 
+  res.setHeader('content-type', 'application/jrd+json');
   return res.json(JSON.parse(webfinger));
 });
 


### PR DESCRIPTION
* Use `application/jrd+json` content type for JRD responses.
* Verify resource matches Postmarks account.
* Use 404 status for unsupported resource URI scheme.

WebFinger uses 400 for malformed requests (where the URI syntax is invalid, the `resource` parameter is missing, or the URI query parameters are otherwise not conformant to the RFC). An unsupported resource URI scheme in a syntactically-valid URI isn't malformed. However, 404 makes sense given the resource is not known to the server.