### PR TITLE
Files for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:alpine
+
+WORKDIR /app
+COPY package.json /app/package.json
+RUN npm install
+
+COPY public /app/public
+COPY server.js /app/server.js
+COPY src /app/src
+
+RUN npm install
+EXPOSE 3000
+ENTRYPOINT ["npm","run","start"]

--- a/README.md
+++ b/README.md
@@ -15,21 +15,30 @@ Check the setup below to understand how to do that!
 
 To set your app up:
 
-- If you're using Glitch:
+If you're using Glitch:
+
   - Rename your project immediately in the project settings, if you intend to be called something else. This determines the domain that your site lives at, which also determines the second half of your `@username@project-name.glitch.me` identity on the fediverse. NOTE: If you change this later, you will break the connection any existing followers have to your site, they'll have to re-follow the account on its new domain (and depending on the software they're following from, may even prevent them from unfollowing the old URL 😱)
   - In your `.env` editor, create a key `ADMIN_KEY` and give it a text string as a value. This is your "password" when your browser prompts you, so make it as secure as you need to protect your data.
   - Add another key to your .env called `SESSION_SECRET` and generate a random string for its value. This is your [session secret](http://expressjs.com/en/resources/middleware/session.html#secret), used to generate the hashed version of your session that gets encoded with the cookies used to store your login. If you make this string too easily guessable, you make it easier for someone to hijack your session and gain unauthorized login. Also, if you ever change this string, it will invalidate all existing cookies.
   - If you've got a custom domain in front of your Glitch project, add a key to your .env called `PUBLIC_BASE_URL` with the value set to the hostname (the part after the https://) at which you want the project to be accessible.
   - Edit the contents of `account.json.example` to set your `@username`, display name, bio, and avatar. (If you don't set a username, your default actor name will be 'bookmarks', so people will find you on the fediverse `@bookmarks@project-name.glitch.me`.)
   - THEN: either rename `account.json.example` to `account.json`, or copy the contents into a new file called `account.json`. Whatever `username` you have in this file when the project first starts you'll need to retain or else you'll break your followers' connection to this account.
-- Otherwise:
+
+Otherwise:
   - Create a `.env` file in the root of the project.
   - Add the line `PUBLIC_BASE_URL=<hostname>` to your .env where \<hostname\> is the hostname of your instance.
   - Add the line `ADMIN_KEY=<key>` to your .env where \<key\> is the password you'll enter when the browser prompts you, and another line for `SESSION_SECRET=<secret>` where \<secret\> is a random string used when hashing your session for use in a secure cookie.
   - Make a file called `account.json` in the project root. Copy the contents of `account.json.example` into it and edit the values to set your `@username`, display name, bio, and avatar. (If you don't set a username, your default actor name will be 'bookmarks', so people will find you on the fediverse `@bookmarks@project-name.glitch.me`.)
-- If you're using Glitch, you should be done! If you're running this yourself, run `npm run start` via whatever mechanism you choose to use to host this website.
-- Click on the **Admin** link in the footer, and enter the password (whatever you set ADMIN_KEY to in the .env).
-- You should be logged in, at which point you can configure various settings, import bookmarks, and use the "Add" links in the header and footer (as well as the bookmarklet, available in the Admin section) to save new bookmarks.
+
+If you're using Glitch, you should be done! 
+
+If you are using Docker compose you can run `docker compose up` or `docker-compose up` (depending on the version of Docker you are using) and Postmarks should be running. You can access it at http://localhost:3000
+
+Otherwise, run `npm run start` via whatever mechanism you choose to use to host this website.
+
+Click on the **Admin** link in the footer, and enter the password (whatever you set ADMIN_KEY to in the .env).
+
+You should be logged in, at which point you can configure various settings, import bookmarks, and use the "Add" links in the header and footer (as well as the bookmarklet, available in the Admin section) to save new bookmarks.
 
 ## Mastodon Verification
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+
+   postmarks:
+      build: .
+      env_file: .env
+      ports:
+        - "127.0.0.1:3000:3000"
+      volumes:
+         - ./.data:/app/.data
+         - ./account.json:/app/account.json:ro


### PR DESCRIPTION
I have added two files to start the postmarks server inside of a docker container. Using the `Dockerfile` you can build the image like this:

```shell
docker build -t postmarks . 
```

Or you can use `docker-compose` instead and start the server with `docker compose up -d`. The configuration is still read from `.env` and `account.json`. The persistent data is still stored in `.data`.