### PR TITLE
Adjust ActivityPub bookmark representation to match Betula

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules
 *.patch
 request_logs.txt
 .DS_Store
+account.json

--- a/src/activitypub.js
+++ b/src/activitypub.js
@@ -48,8 +48,9 @@ export function createNoteObject(bookmark, account, domain) {
       .join(' ');
   }
 
+  let escapedDescription = '';
   if (updatedBookmark.description?.trim().length > 0) {
-    updatedBookmark.description = `<br/>${updatedBookmark.description?.trim().replace('\n', '<br/>') || ''}`;
+    escapedDescription = `<br/>${updatedBookmark.description?.trim().replace('\n', '<br/>') || ''}`;
   }
 
   if (linkedTags.trim().length > 0) {
@@ -57,17 +58,29 @@ export function createNoteObject(bookmark, account, domain) {
   }
 
   const noteMessage = {
-    '@context': 'https://www.w3.org/ns/activitystreams',
+    '@context': ['https://www.w3.org/ns/activitystreams', { Hashtag: 'https://www.w3.org/ns/activitystreams#Hashtag' }],
     id: `https://${domain}/m/${guidNote}`,
     type: 'Note',
     published: d.toISOString(),
     attributedTo: `https://${domain}/u/${account}`,
+    name: updatedBookmark.title,
     content: `<p><strong><a href="${updatedBookmark.url}" rel="nofollow noopener noreferrer">${replaceEmptyText(
       updatedBookmark.title,
       updatedBookmark.url,
-    )}</a></strong>${updatedBookmark.description}</p>${linkedTags}`,
+    )}</a></strong>${escapedDescription}</p>${linkedTags}`,
     to: [`https://${domain}/u/${account}/followers/`, 'https://www.w3.org/ns/activitystreams#Public'],
     tag: [],
+    url: `https://${domain}/bookmark/${updatedBookmark.id}`,
+    source: {
+      content: updatedBookmark.description,
+      mediaType: 'text/plain',
+    },
+    attachment: [
+      {
+        type: 'Link',
+        href: updatedBookmark.url,
+      },
+    ],
   };
 
   bookmark.tags?.split(' ').forEach((tag) => {
@@ -262,7 +275,8 @@ export async function broadcastMessage(bookmark, action, db, account, domain) {
 
     // eslint-disable-next-line no-restricted-syntax
     for (const follower of followers) {
-      const inbox = `${follower}/inbox`;
+      console.log(`Sending to ${follower}...`);
+      const inbox = await getInboxFromActorProfile(follower);
       const myURL = new URL(follower);
       const targetDomain = myURL.host;
       signAndSend(message, account, domain, db, targetDomain, inbox);

--- a/src/signature.js
+++ b/src/signature.js
@@ -74,7 +74,7 @@ function getSignatureParams(body, method, url) {
  */
 function getSignatureHeader(signature, signatureKeys) {
   return [
-    `keyId="https://${domain}/u/${account}"`,
+    `keyId="https://${domain}/u/${account}#main-key"`,
     `algorithm="rsa-sha256"`,
     `headers="${signatureKeys.join(' ')}"`,
     `signature="${signature}"`,


### PR DESCRIPTION
Hello!

This pull request changes the way bookmarks are represented over ActivityPub so they can be displayed by Betula. The same format is also used by Ties and Omnom. I'm also writing a FEP for this format.

I also fixed a bug with public keys.

This is what a Postmarks bookmark looks like in Betula:

<img width="651" height="203" alt="Screenshot 2026-07-01 at 04 15 37" src="https://github.com/user-attachments/assets/3b612540-63d1-44db-9721-5f5480a223f9" />

And in Mastodon:

<img width="594" height="421" alt="Screenshot 2026-07-01 at 04 28 54" src="https://github.com/user-attachments/assets/4a156655-b4c8-4eeb-a1f4-25ee28c6b33b" />
